### PR TITLE
Update welcome.htm to correct Corsican strings

### DIFF
--- a/bin/setup/lang/welcome.htm
+++ b/bin/setup/lang/welcome.htm
@@ -276,19 +276,19 @@ sv: <a href="gwsetup?lang=%l;v=update_nldb.htm">Uppdatera länksida / släktkrö
 ] (update_nldb)
 
 <li>[
-fr: <a href="gwsetup?lang=%l;v=connex.htm">Calcula i cumpunenti cunnessi</a>
+fr: <a href="gwsetup?lang=%l;v=connex.htm">Calculeghja i cumpunenti cunnessi</a>
 en: <a href="gwsetup?lang=%l;v=connex.htm">Compute connected componants</a>
 fr: <a href="gwsetup?lang=%l;v=connex.htm">Calcule les composantes connexes</a>
 ] (connex)
 
 <li>[
-co: <a href="gwsetup?lang=%l;v=gwdiff.htm">Calcula a sfarenza trà duie base</a>
+co: <a href="gwsetup?lang=%l;v=gwdiff.htm">Calculeghja a sfarenza trà duie base</a>
 en: <a href="gwsetup?lang=%l;v=gwdiff.htm">Compute the difference between two bases</a>
 fr: <a href="gwsetup?lang=%l;v=gwdiff.htm">Calcule la différence entre deux bases</a>
 ] (gwdiff)
 
 <li>[
-co: <a href="gwsetup?lang=%l;v=gwfix.htm">Currege una basa et calculeghja torna l’indici</a>
+co: <a href="gwsetup?lang=%l;v=gwfix.htm">Currege una basa è calculeghja torna l’indici</a>
 en: <a href="gwsetup?lang=%l;v=gwfix.htm">Fix a base and recompute index</a>
 fr: <a href="gwsetup?lang=%l;v=gwfix.htm">Corrige une base et recalcule les index</a>
 ] (gwfixbase)


### PR DESCRIPTION
@hgouraud 
Hello Henri,

I'm sorry but I just noticed a typo on the Corsican string previously communicated for `gwfix`; the correct syntax is:

`co: <a href="gwsetup?lang=%l;v=gwfix.htm">Currege una basa è calculeghja torna l’indici</a>`

I also corrected the two other strings which have been modified on geneweb repository via issue #988.

Cheers,
Patriccollu.