### PR TITLE
Updating lex_co.txt with missing Corsican strings

### DIFF
--- a/bin/setup/lang/missing/lex_co.txt
+++ b/bin/setup/lang/missing/lex_co.txt
@@ -1,1775 +1,1774 @@
     !languages
-en: af=Afrikaans|bg=Bulgarian|br=Breton|ca=Catalan|cs=Czech|da=Danish|de=German|en=English|eo=Esperanto|es=Spanish|et=Estonian|fi=Finnish|fr=French|he=Hebrew|is=Icelandic|it=Italian|lv=Latvian|nl=Dutch|no=Norwegian|oc=Occitan|pl=Polish|pt=Portuguese|pt-br=Brazilian-Portuguese|ro=Romanian|ru=Russian|sk=Slovak|sl=Slovenian|sv=Swedish|zh=Chinese
-fr: af=afrikaans|bg=bulgare|br=breton|ca=catalan|cs=tchèque|da=danois|de=allemand|en=anglais|eo=espéranto|es=espagnol|et=estonien|fi=finnois|fr=français|he=hébreu|is=islandais|it=italien|lv=letton|nl=néerlandais|no=norvégien|oc=occitan|pl=polonais|pt=portugais|pt-br=portugais du Brésil|ro=roumain|ru=russe|sk=slovaque|sl=slovène|sv=suédois|zh=chinois
-co:
+en: af=Afrikaans|bg=Bulgarian|br=Breton|ca=Catalan|co=Corsican|cs=Czech|da=Danish|de=German|en=English|eo=Esperanto|es=Spanish|et=Estonian|fi=Finnish|fr=French|he=Hebrew|is=Icelandic|it=Italian|lv=Latvian|nl=Dutch|no=Norwegian|oc=Occitan|pl=Polish|pt=Portuguese|pt-br=Brazilian-Portuguese|ro=Romanian|ru=Russian|sk=Slovak|sl=Slovenian|sv=Swedish|zh=Chinese
+fr: af=afrikaans|bg=bulgare|br=breton|ca=catalan|co=corse|cs=tchèque|da=danois|de=allemand|en=anglais|eo=espéranto|es=espagnol|et=estonien|fi=finnois|fr=français|he=hébreu|is=islandais|it=italien|lv=letton|nl=néerlandais|no=norvégien|oc=occitan|pl=polonais|pt=portugais|pt-br=portugais du Brésil|ro=roumain|ru=russe|sk=slovaque|sl=slovène|sv=suédois|zh=chinois
+co: af=Africanu|bg=Bulgaru|br=Brittonu|ca=Catalanu|co=Corsu|cs=Ceccu|da=Danese|de=Tedescu|en=Inglese|eo=Esperanto|es=Spagnolu|et=Estonianu|fi=Finlandese|fr=Francese|he=Ebreu|is=Islandese|it=Talianu|lv=Lettonu|nl=Neerlandese|no=Nurvegese|oc=Occitanicu|pl=Pulunese|pt=Purtughese|pt-br=Purtughese Brasilianu|ro=Rumanu|ru=Russiu|sk=Sluvaccu|sl=Slovenu|sv=Svedese|zh=Chinese
 
     "first names enclosed": the -fne option must be followed by a two characters string "be". When creating a person, if the GEDCOM first name part holds a part between 'b' (any character) and 'e' (any character), it is considered to be the usual first name: e.g. -fne "\\" or -fne "()".
 en: "first names enclosed": the -fne option must be followed by a two characters string "be". When creating a person, if the GEDCOM first name part holds a part between 'b' (any character) and 'e' (any character), it is considered to be the usual first name: e.g. -fne "\\" or -fne "()".
 fr: L’option <i>first names enclosed</i> doit être suivie par une chaîne de deux caractères « be ». À la création d’une personne, si une partie de la chaîne prénom commence par le caractère 'b' et se termine par le caractère 'e', alors cette partie sera considérée comme le prénom usuel.<br> Exemples : <span  style="font-family: monospace">-fne "\\"</span> ou <span style="font-family: monospace"> -fne "()"</span>.
-co:
+co: L’ozzione « first names enclosed » deve esse seguitata da una catena di dui caratteri di u furmatu "pf". Durante a creazione d’una persona, s’è una parte di a catena <i>nome</i> di u schedariu GEDCOM <b>p</b>rincipia da u caratteru 'p' è si <b>f</b>inisce da u caratteru 'f', sta parte serà impiegata per u nome usuale. Esempii : <span  style="font-family: monospace">-fne "\\"</span> o <span style="font-family: monospace"> -fne "()"</span>.
 
     "Friends" can see all dates, notes and photos of the persons born since less than one century. The ones who have not entered the below password will not see these informations.
 en: "Friends" can see all dates, notes and photos of the persons born since less than one century. The ones who have not entered the below password will not see these informations.
 fr: Les « amis » peuvent voir toutes les dates, notes et photos des personnes nées depuis moins d’un siècle. Ceux qui n’ont pas entré le mot de passe ci-dessous ne verront pas ces informations.
-co:
+co: L’« amichi » ponu vede tutte e date, note è fotò di e persone chì sò nate dapoi menu d’un seculu. Quelli chì ùn anu micca pruvistu a parolle d’entrata quaghjò ùn videranu micca st’infurmazioni.
 
     "Wizards" become simple "friend".
 en: "Wizards" become simple "friend".
 fr: Les "magiciens" deviennent de simples "amis".
-co:
+co: I « maghi » diventanu « amichi » simplice.
 
     "Wizards" can moreover make modifications in the database.
 en: "Wizards" can moreover make modifications in the database.
 fr: Les "magiciens" peuvent en outre faire des modifications dans la base de données.
-co:
+co: D’altronde, i « maghi » ponu fà mudificazioni in a basa di dati.
 
     (do not enter the quotes "" in the input zone).
 en: (do not enter the quotes "" in the input zone).
 fr: (ne pas inclure les guilemets "" dans le champ de saisie).
-co:
+co: (ùn micca inchjude e virgulette "" in u campu di scrittura).
 
     (no selection is equivalent to select all).
 en: (no selection is equivalent to select all).
-fr: (aucune option est équivalent à les sélectionner toutes). 
-co:
+fr: (aucune option est équivalent à les sélectionner toutes).
+co: (ùn ci hè nisuna ozzione per tutte selezziunalle).
 
     , and overwrite the database "%o" of the destination directory
 en: , and overwrite the database "%o" of the destination directory
 fr:  et écraser la base "%o" du répertoire d’arrivée
-co:
+co:  è rimpiazzà a basa « %o » in u cartulare di destinazione
 
     , and overwrite the previous database "%o" of the target directory
 en: , and overwrite the previous database "%o" of the target directory
 fr:  et écraser la base "%o" du répertoire d’arrivée
-co:
+co:  è rimpiazzà a basa « %o » in u cartulare di destinazione
 
     ../ allows you to reach the parent directory.<br> In the Windows world, this will be insufficient to change the drive letter (C: -> D:), but you can do this directly in the url in your navigator.
 en: ../ allows you to reach the parent directory.<br> In the Windows world, this will be insufficient to change the drive letter (C: -> D:), but you can do this directly in the url in your navigator.
 fr: ../ vous permet de naviguer vers le dossier parent.<br> Dans le monde Windows, ceci ne vous permettra pas de changer la lettre du disque (C: -> D:), mais vous pouvez faire ce changement directement dans l'url dans le navigateur.
-co:
+co: ../ vi permette di navigà fine à u cartulare di a radica.<br> In u mondu Windows, st’azzione ùn vi permitterà micca di cambià a lettera di u lettore (C: -> D:), ma puderete fà què direttamente in l’indirizzu di u vostru navigatore.
 
     <span style="color:#FF0000;">WARNING</span>: the -del command suppresses irreversibly some families. It may be prudent to have a backup archive.
 en: <span style="color:#FF0000;">WARNING</span>: the -del command suppresses irreversibly some families. It may be prudent to have a backup archive.
 fr: <span style="color:#FF0000;">ATTENTION</span> : la commande -del supprime des familles de façon irréversible. Il peut être prudent d'avoir une archive de sauvegarde.
-co:
+co: <span style="color:#FF0000;">AVERTIMENTU</span> : a cumanda -del squasseghja certe famiglie di manera irriversibile. Forse seria una bella idea d’avè un archiviu di salvaguardia.
 
     <span style="color:#FF0000;">WARNING</span>: The content of file %o will be overwritten.
 en: <span style="color:#FF0000;">WARNING</span>: The content of file %o will be overwritten.
 fr: <span style="color:#FF0000;">ATTENTION</span> : Le contenu du fichier %o sera écrasé.
-co:
+co: <span style="color:#FF0000;">AVERTIMENTU</span> : U cuntenutu di u schedariu %o serà rimpiazzatu.
 
     <span style="color:#FF0000;">WARNING</span>: The following three options result in irreversible deletions. Having a backup archive is recommended.
 en: <span style="color:#FF0000;">WARNING</span>: The following three options result in irreversible deletions. Having a backup archive is recommended.
 fr: <span style="color:#FF0000;">ATTENTION</span> : Les trois commandes qui suivent résultent en la destruction irréversible de familles. Disposer d'une archive serait prudent.
-co:
+co: <span style="color:#FF0000;">AVERTIMENTU</span> : E trè cumande chì seguitanu ponu squassà parechje famiglie di manera irriversibile. Avè un archiviu di salvaguardia hè ricumandatu.
 
     <span style="color:#FF0000;">WARNING</span>: this command modifies the base irreversibly. It may be prudent to have a backup archive.
 en: <span style="color:#FF0000;">WARNING</span>: this command modifies the base irreversibly. It may be prudent to have a backup archive.
 fr: <span style="color:#FF0000;">ATTENTION</span> : cette commande modifie la base de façon irréversible. Il peut être prudent d'avoir une archive de sauvegarde.
-co:
+co: <span style="color:#FF0000;">AVERTIMENTU</span> : sta cumanda mudificheghja a basa di manera irriversibile. Forse seria una bella idea d’avè un archiviu di salvaguardia.
 
     Ability to send images.
 en: Ability to send images.
 fr: Possibilité d’envoyer des images.
-co:
+co: Pussibilità di mandà fiure.
 
     All connex components.
 en: All connex components.
 fr: Toutes les composantes connexes.
-co:
+co: Tutti i cumpunenti cunnessi.
 
     All your databases to be merged must be first under %G.
 en: All your databases to be merged must be first under %G.
 fr: Il faut d’abord que toutes vos bases à fusionner soient sous %G.
-co:
+co: In primu locu, tutte e vostre base à unisce devenu esse sottu à %G.
 
     Allows to change the background color, put a background pattern, or change the color of the text or the links. Its syntax is the one of HTML accepted in the tag "&lt;body&gt;" before the ">". See your HTML documentation. Example:
 en: Allows to change the background color, put a background pattern, or change the color of the text or the links. Its syntax is the one of HTML accepted in the tag "&lt;body&gt;" before the ">". See your HTML documentation. Example:
 fr: Permet de configurer les couleurs de fond, ou d’y mettre un motif et de changer la couleur du texte et des liens. Sa syntaxe est la syntaxe HTML acceptée dans le tag "&lt;body&gt;" avant le ">". Voyez votre documentation HTML. Exemple:
-co:
+co: Permette di cunfigurà i culori di u fondu, di metteci un mudellu, o di cambià u culore di u testu o di i liami. A so sintassa hè quella di HTML accettata in l’etichetta "&lt;body&gt;" nanzu u ">". Fighjà a vostra documentazione HTML. Esempiu :
 
     And the content of gwsetup.log
 en: And the content of gwsetup.log
 fr: Et le contenu de gwsetup.log
-co:
+co: È u cuntenutu di gwsetup.log
 
     Application of "%d"
 en: Application of "%d"
 fr: Application de "%d"
-co:
+co: Appiecazione di « %d »
 
     Apply
 en: Apply
 fr: Appliquer
-co:
+co: Appiecà
 
     Apply on a database
 en: Apply on a database
 fr: Appliquer sur une base de données
-co:
+co: Appiecà nant’à una basa di dati
 
     Are you sure you want to delete these databases?
 en: Are you sure you want to delete these databases?
 fr: Êtes-vous sûr de vouloir supprimer ces bases?
-co:
+co: Site sicuru di vulè squassà ste base di dati ?
 
     Ask for deleting branches whose size <= that value.
 en: Ask for deleting branches whose size <= that value.
 fr: Demander à détruire les composantes de taille <= à cette valeur.
-co:
+co: Dumandà di squassà i cumpunenti di dimensione <= à stu valore.
 
     Ask to indicate the updates in the welcome pages as a link "history of updates". <p> Remark (technical): the updates traces are saved in a file named "history" in the directory of the database (%a.gwb). This file grows indefinitively. You can edit it to remove the old information. Or you can also delete this file to restart empty.
 en: Ask to indicate the updates in the welcome pages as a link "history of updates". <p> Remark (technical): the updates traces are saved in a file named "history" in the directory of the database (%a.gwb). This file grows indefinitively. You can edit it to remove the old information. Or you can also delete this file to restart empty.
 fr: Demande d’indiquer les mises à jour dans la page d’accueil sous le lien "historique des mises à jour". <p> Remarque (technique): les traces des mises à jour sont sauvées dans un fichier de nom "history" dans le répertoire de la base de donnée (%a.gwb). Ce fichier grossit indéfiniment. Si vous voulez effacer les anciennes traces, il faut éditer ce fichier pour les supprimer. Ou vous pouvez aussi supprimer le fichier pour repartir à vide.
-co:
+co: Dumandà d’affissà e mudificazioni nant’à a pagina d’accolta sottu u liame « cronolugia di e mudificazioni ». <p> Rimarca (technica) : e traccie di e mudificazioni sò arregistrate in u schedariu chì si chjama « history » in u cartulare di a basa di dati (%a.gwb). A so dimensione cresce indefinitamente. Pudete mudificallu per caccià e vechje infurmazioni. O pudete dinù squassallu per riparte à viotu.
 
     background color
 en: background color
 fr: couleur de fond
-co:
+co: culore di fondu
 
     background image
 en: Background image
 fr: Fond d’écran
-co:
+co: Fiura di fondu
 
     Base has been renamed.
 en: Base has been renamed.
 fr: Base renommée.
-co:
+co: A basa hè stata rinuminata.
 
     But it does not hold the command "gwu" required to transfer your database. Are you sure it is a %G distribution directory
 en: But it does not hold the command "gwu" required to transfer your database. Are you sure it is a %G distribution directory
 fr: Mais celui-ci ne contient pas la commande "gwu" nécessaire au transfert de votre base de données. Êtes-vous sûr qu’il s’agit bien d’un répertoire d’une distribution %G
-co:
+co: Ma ùn cuntene micca a cumanda « gwu » richiesta per u trasferimentu di a vostra basa di dati. Site sicuru chì ghjè un cartulare d’una distribuzione %G
 
     By default the connection traces appear in the window of "gwd". Each time you navigate, or somebody accesses to one of your databases, 4 or 5 lines are displayed.
 en: By default the connection traces appear in the window of "gwd". Each time you navigate, or somebody accesses to one of your databases, 4 or 5 lines are displayed.
 fr: Par défaut, les traces de connexion apparaissent dans la fenêtre de "gwd". Chaque fois qu’on navigue, ou que quelqu’un accède à une de vos bases de données, on voit s’afficher 4 ou 5 lignes.
-co:
+co: Di regula, e traccie di cunnessione si vedenu in a finestra di « gwu ». Quandu si navigheghja, o chì qualchissia accede à una di e vostre base di dati, 4 o 5 linee ci sò affissate.
 
     By default, all the pages of the databases are displayed in this language. Select your prefered language.
 en: By default, all the pages of the databases are displayed in this language. Select your prefered language.
 fr: Par défaut, les pages de toutes les bases de données sont affichées dans cette langue. Sélectionnez votre langue de préférence.
-co:
+co: Di regula, tutte e pagine di e base di dati sò affissate in sta lingua. Selezziunate a vostra lingua preferita.
 
     By default, when creating a person, if the GEDCOM first name part looks like a public name, i.e. holds: <ul> <li>A number or a roman number, supposed to be a number of a nobility title (e.g. George V) <li>One of the words: "der", "den", "die", "el", "le", "la", "the", supposed to be the beginning of a qualifier (e.g. William the Conqueror) </ul> then the GEDCOM first name part becomes the person "public name" and its first word his "first name" (-epn default).
 en: By default, when creating a person, if the GEDCOM first name part looks like a public name, i.e. holds: <ul> <li>A number or a roman number, supposed to be a number of a nobility title (e.g. George V) <li>One of the words: "der", "den", "die", "el", "le", "la", "the", supposed to be the beginning of a qualifier (e.g. William the Conqueror) </ul> then the GEDCOM first name part becomes the person "public name" and its first word his "first name" (-epn default).
 fr: Par défaut, au moment de la création d’une personne, si la partie prénom dans le GEDCOM ressemble à un nom public, c’est-à-dire si elle contien contient :<ul> <li> un nombre normal ou en chiffres romains, censé être un numéro d’un titre de noblesse (exemple : Louis XIV) ; <li> un des mots : « der », « den », « die », « el », « le », « la », « the », censé être le début d’un qualificatif (exemple : Guillaume le Conquérant) ; </ul> alors le prénom dans le GEDCOM devient un « nom public » et le premier mot de la partie prénom va dans la partie « prénom» (-epn par défaut).
-co:
+co: Di regula, quandu si crea una persona, s’è a parte di u <i>nome</i> di u schedariu GEDCOM s’assumiglia à una casata publica, i.e. cuntene : <ul> <li>un numeru nurmale o cifri rumani chì seria un numeru d’un titulu di nubiltà (esempiu: Louis XIV) ; <li>una di e parolle : « der », « den », « die », « el », « le », « la », « the », suppostu esse u principiu d’un qualificativu (esempiu : Guillaume le Conquérant) ; </ul> tandu u nome di u GEDCOM diventeghja una « casata publica » è a prima parolla di a parte di u nome và in a parte « nome» (-epn predefinitu).
 
     By looking at the terminal window if you have not asked for result redirection.
 en: By looking at the terminal window if you have not asked for result redirection.
 fr: En regardant dans la fenêtre qui s'est ouverte si vous n'avez pas demandé de redirection des résultats.
-co:
+co: Fighjendu in a finestra chì s’hè aperta s’è ùn avete micca dumandatu di ridirezzione di i risultati.
 
     By origin file.
 en: By origin file.
 fr: D'après le fichier origine.
-co:
+co: Secondu u schedariu d’origine.
 
     Can be useful in local, in order to be able to put an image for somebody, because the procedure installs automatically the image at the right place with the appropriate file name.
 en: Can be useful in local, in order to be able to put an image for somebody, because the procedure installs automatically the image at the right place with the appropriate file name.
 fr: Peut être utile en local pour pouvoir mettre une image à des personnes, car la procédure installe automatiquement la photo au bon endroit avec le nom approprié.
-co:
+co: Pò esse ghjuvevule in lucale per pudè assucià una fiura à qualchissia, perchè a prucedura installeghja autumaticamente a fiura à a so piazza cù u nome appostu.
 
     cancel
 en: Cancel
 fr: Annuler
-co:
+co: Abbandunà
 
     Cancel this option.
 en: Cancel this option.
 fr: Annuler cette option.
-co:
+co: Annullà st’ozzione.
 
     Change the names you want
 en: Change the names you want
 fr: Changez le ou les noms que vous désirez 
-co:
+co: Cambiate u nome o tutti quelli chì vò vulete
 
     Check
 en: Check
 fr: Vérifier
-co:
+co: Cuntrollà
 
     Checks descendants (default).
 en: Checks descendants (default).
 fr: Vérifier les descendants (par défaut).
-co:
+co: Cuntrollà i discendenti (predefinitu)
 
     Checks descendants of all ascendants.
 en: Checks descendants of all ascendants.
 fr: Vérifier tous les descendants des ascendants.
-co:
+co: Cuntrollà i discendenti di tutti l’ascendenti.
 
     Cleaning up a database
 en: Cleaning up a database
 fr: Nettoyage d’une base de données
-co:
+co: Nettata d’una basa di dati
 
     Cleanup
 en: Clean up
 fr: Nettoyage
-co:
+co: Nettata
 
     Cleanup - Phase 2
 en: Clean up - Phase 2
 fr: Nettoyage - Phase 2
-co:
+co: Nettata - Fasa 2
 
     color of already visited links
 en: color of already visited links
 fr: couleur des liens déjà visités
-co:
+co: culore di i liami dighjà visitati
 
     Compare
 en: Compare
 fr: Comparer
-co:
+co: Paragunà
 
     Connected components identified
 en: Connected components identified
 fr: Calcul des composantes connexes exécuté
-co:
+co: Cumpunenti cunnessi identificati
 
     Connection log file.
 en: Connection log file.
 fr: Fichier de traces de connexion.
-co:
+co: Schedariu di e traccie di cunnessione.
 
     Connex
 en: Connex
 fr: Connex
-co:
+co: Connex
 
     Consang
 en: Consang
 fr: Consang
-co:
+co: Consang
 
     Consanguinities
 en: Consanguinities
 fr: Initialisation des consanguinités
-co:
+co: Iniziu di e consanguinità
 
     Content of comm.log
 en: Content of comm.log
 fr: Contenu du fichier comm.log
-co:
+co: Cuntenutu di u schedariu comm.log
 
     Content of result file
 en: Content of result file
 fr: Contenu du fichier résultat
-co:
+co: Cuntenutu di u schedariu risultatu
 
     Convert first names to lowercase letters, with initials in uppercase.
 en: Convert first names to lowercase letters, with initials in uppercase.
 fr: Convertir les prénoms en minuscules, avec leurs initiales en majuscules.
-co:
+co: Cunvertisce i nomi in minuscule, cù e so iniziali in maiuscula.
 
     Convert surnames to lowercase letters, with initials in uppercase. Try to keep lowercase particles.
 en: Convert surnames to lowercase letters, with initials in uppercase. Try to keep lowercase particles.
 fr: Convertir les noms de famille en minuscules, avec leurs initiales en majuscules. Essaye de garder les particules en minuscules.
-co:
+co: Cunvertisce e casate in minuscule, cù e so iniziali in maiuscula. Pruvà di cunservà e particule in minuscule.
 
     Create
 en: Create
 fr: Créer
-co:
+co: Creà
 
     Create a database
 en: Create a database
 fr: Créer une base de données
-co:
+co: Creà una basa di dati
 
     Creation of a database
 en: Creation of a database
 fr: Création d’une généalogie
-co:
+co: Creazione d’una genealugia
 
     Database created
 en: Database created
 fr: Généalogie créée
-co:
+co: Basa di genealugia creata
 
     Databases
 en: Databases
 fr: Bases de données
-co:
+co: Base di dati
 
     Databases deleted
 en: Databases deleted
 fr: Bases détruites
-co:
+co: Base di dati squassate
 
     Default language.
 en: Default language.
 fr: Langue par défaut.
-co:
+co: Lingua predefinita.
 
     Default source
 en: Default source
 fr: Source par défaut
-co:
+co: Fonte predefinita
 
     Delete
 en: Delete
 fr: Détruire
-co:
+co: Squassà
 
     Delete database if already existing.
 en: Delete database if already existing.
 fr: Détruire la base pré-existante.
-co:
+co: Squassà a basa di dati s’ella esiste dighjà.
 
     Deletion of databases
 en: Deletion of databases
 fr: Suppression de bases  de données
-co:
+co: Squassatura di base di dati
 
     Destination directory and database
 en: Destination directory and database
 fr: Répertoire et base d’arrivée
-co:
+co: Cartulare è basa di dati di destinazione
 
     Details for this length.
 en: Details for this length.
 fr: Fournir détails pour cette taille.
-co:
+co: Pruvede detaglii per sta longhezza.
 
     Differences computed
 en: Differences computed
 fr: Différence calculée
-co:
+co: Sfarenza calculata
 
     Directory
 en: Directory
 fr: Répertoire :
-co:
+co: Cartulare
 
     Display some statistics at the end (they will be visible in the traces).
 en: Display some statistics at the end (they will be visible in the traces).
 fr: Afficher quelques statistiques à la fin (elles seront visibles dans les traces).
-co:
+co: Affissà certe statistiche à a fine (chì seranu videvule in e traccie).
 
     Do not check the consistency of the data.
 en: Do not check the consistency of the data.
 fr: Ne pas vérifier la cohérence des données.
-co:
+co: Ùn micca verificà a cuerenza di i dati.
 
     do not commit changes (only traces).
 en: do not commit changes (only traces).
 fr: ne pas effectuer les changements (traces seules).
-co:
+co: ùn micca effettuà i cambiamenti (solu in e traccie).
 
     Do not extract notes.
 en: Do not extract notes.
 fr: Ne pas extraire les notes.
-co:
+co: Ùn micca estrae e note.
 
     Do not extract spouses' parents (for options -s and -d).
 en: Do not extract spouses' parents (for options -s and -d).
 fr: Ne pas extraire les parents des époux (pour les options -s et -d).
-co:
+co: Ùn micca estrae i genitori di i sposi (per l’ozzioni -s è -d).
 
     Don't extract individual picture.
 en: Don't extract individual picture.
 fr: Ne pas extraire d’images individuelles.
-co:
+co: Ùn micca estrae di fiura individuale.
 
     Done. The operation is terminated.
 en: Done. The operation is terminated.
 fr: L’opération est terminée.
-co:
+co: Eccu. L’operazione hè compia.
 
     Done. The operation is terminated. Your database named "%o" is created.
 en: Done. The operation is terminated. Your database named "%o" is created.
 fr: L’opération est terminée : votre généalogie "%o" est créée.
-co:
+co: Eccu. L’operazione hè compia. A vostra basa di genealugia « %o » hè stata creata.
 
     Dont extract individual pictures (portraits).
 en: Dont extract individual pictures (portraits).
 fr: Ne pas extraire les images individuelles (portraits).
-co:
+co: Ùn micca estrae e fiure individuale (ritratti).
 
     empty file
 en: empty file
 fr: fichier vide
-co:
+co: schedariu viotu
 
     Encode the characters in ANSEL.
 en: Encode the characters in ANSEL.
 fr: Coder les caractères en ANSEL.
-co:
+co: Cudificà i caratteri in ANSEL.
 
     Encode the characters in ANSI (ISO 8859-1).
 en: Encode the characters in ANSI (ISO 8859-1).
 fr: Coder les caract&egrave;res en ANSI (ISO 8859-1).
-co:
+co: Cudificà i caratteri in ANSI (ISO 8859-1).
 
     Encode the characters in ASCII.
 en: Encode the characters in ASCII.
 fr: Coder les caractères en ASCII.
-co:
+co: Cudificà i caratteri in ASCII.
 
     Encode the characters in UTF-8.
 en: Encode the characters in UTF-8.
 fr: Coder les caractères en UTF-8.
-co:
+co: Cudificà i caratteri in UTF-8.
 
     End by the initialization of consanguinities.
 en: End by the initialization of consanguinities.
 fr: Terminer par le précalcul de consanguinité.
-co:
+co: Finisce da u pre-calculu di e cunsanguinità.
 
     Enter the name you want to give to your %G database.
 en: Enter the name you want to give to your %G database.
 fr: Entrez le nom que vous voulez donner à votre base de données %G.
-co:
+co: Scrivite u nome chì vò vulete dà à a vostra basa di dati %G.
 
     Enter The name you want to give to your %G database. If omitted, it will be deducted from the name of the GEDCOM file.
 en: Enter The name you want to give to your %G database. If omitted, it will be deducted from the name of the GEDCOM file.
 fr: Entrez le nom que vous voulez donner à votre base de données %G. Si vous ne mettez rien, il sera déduit du nom du fichier GEDCOM.
-co:
+co: Scrivite u nome chì vò vulete dà à a vostra basa di dati %G. S’ellu hè omessu, serà deduttu secondu u nome di u schedariu GEDCOM.
 
     Enter the name you want to give to your %G source file. Its name must end with the suffix "<tt>.gw</tt>". If you write nothing, its name will be deducted from the name of the database.
 en: Enter the name you want to give to your %G source file. Its name must end with the suffix "<tt>.gw</tt>". If you write nothing, its name will be deducted from the name of the database.
 fr: Entrez le nom que vous voulez donner à votre fichier source %G. Il doit se terminer par "<tt>.gw</tt>".  Si vous ne mettez rien, ce sera déduit du nom de la base.
-co:
+co: Scrivite u nome chì vò vulete dà à u vostru schedariu di fonte %G. U so nome deve finisce cù u suffissu « <tt>.gw</tt> ». S’è ùn scrivite nunda, u so nome serà deduttu secondu quellu di a basa di dati.
 
     Enter the name you want to give to your GEDCOM file. If you write nothing, it will be the name of the database ended by the suffix
 en: Enter the name you want to give to your GEDCOM file. If you write nothing, it will be the name of the database ended by the suffix
 fr: Entrez le nom que vous voulez donner à votre fichier GEDCOM. Si vous ne mettez rien, ce sera le nom de la base suivi du suffixe
-co:
+co: Scrivite u nome chì vò vulete dà à u vostru schedariu GEDCOM. S’è ùn scrivite nunda, serà u nome di a basa di dati seguitatu da u suffissu.
 
     error
 en: Error
 fr: Erreur
-co:
+co: Sbagliu
 
     Extract
 en: Extract
 fr: Extraire
-co:
+co: Estrae
 
     Extract a GEDCOM file
 en: Extract a GEDCOM file
 fr: Extraction d’un fichier GEDCOM
-co:
+co: Estrazzione d’un schedariu GEDCOM
 
     Extract a GeneWeb file
 en: Extract a %G file
 fr: Extraction d’un fichier %G
-co:
+co: Estrazzione d’un schedariu %G
 
     Extract ancestors with siblings of
 en: Extract ancestors with siblings of
 fr: Extraire les ancêtres avec fratries de
-co:
+co: Estrae l’antenati cù fratelli è surelle
 
     Extract from a database
 en: Extract from a database
 fr: Extraire d’une base de données
-co:
+co: Estrae d’una basa di dati
 
     Extract individual pictures path (portraits).
 en: Extract individual pictures path (portraits).
 fr: Extraire le chemin des images individuelles (portraits).
-co:
+co: Estrae u chjassu di e fiure individuale (ritratti).
 
     Extract only the ancestors of
 en: Extract only the ancestors of
 fr: N’extraire que les ancêtres de
-co:
+co: Estrae solu l’antenati di
 
     Extract only the descendants of
 en: Extract only the descendants of
 fr: N’extraire que les descendants de
-co:
+co: Estrae solu i discendenti di
 
     extract surname (usable several times).
 en: Extract surname (usable several times).
 fr: Extraire un nom de famille (utilisable plusieurs fois).
-co:
+co: Estrae una casata (impieghevule parechje volte).
 
     families' children.
 en: families' children.
 fr: families' children.
-co:
+co: zitelli - famiglie.
 
     families' parents.
 en: families' parents.
 fr: families' parents.
-co:
+co: genitori - famiglie.
 
     fast mode. Needs more memory
 en: fast mode. Needs more memory
 fr: mode rapide. Nécessite plus de mémoire.
-co:
+co: modu rapidu. Richiede più di memoria
 
     fevents' witnesses.
 en: fevents' witnesses.
 fr: fevents' witnesses.
-co:
+co: testimoni - « fevents ».
 
     Files were reconstructed in the original sources directory.<br> Data created without origin file has been directed to the file %o or to comm.log. It is up to you to manage this new source file, or to merge this data into existing files.
 en: Files were reconstructed in the original sources directory.<br> Data created without origin file has been directed to the file %o or to comm.log. It is up to you to manage this new source file, or to merge this data into existing files.
 fr: Les fichiers ont été reconstitués dans le dossier d'origine.<br> Les nouvelles données sans fichier d'origine ont été redirigées vers le fichier %o ou vers comm.log. Il vous revient la tâche de gérer ce nouveau fichier .gw ou d'ajouter ces  données aux fichiers existants.
-co:
+co: I schedarii sò stati ricustituiti in u cartulare d’origine.<br> I novi dati senza schedariu d’origine sò stati inversiati ver di u schedariu %o o ver di comm.log. Tocca à voi d’amministrà stu novu schedariu .gw o d’aghjunghje sti dati à i schedarii esistente.
 
     First name
 en: First name
 fr: Prénom
-co:
+co: Nome
 
     Fix base
 en: Fix base
 fr: Fix base
-co:
+co: Riparà una basa
 
     Fix base and recompute index
 en: Fix base and recompute index
 fr: Corrige une base et reclacule l'index
-co:
+co: Riparà una basa è ricalculeghja l’indice
 
     Follow the indications of the GEDCOM header.
 en: Follow the indications of the GEDCOM header.
 fr: Suivre les indications de l’en-tête du GEDCOM.
-co:
+co: Seguità l’addittamenti di l’intestatura GEDCOM.
 
     foo.jpg
 en: foo.jpg
 fr: toto.jpg
-co:
+co: fiura.jpg
 
     For a given database, you can still change this choice by configurating the specific parameters of this database. And in the welcome page of the base, you can still click on another flag to select another language. The present choice is therefore like a "default default" language.
 en: For a given database, you can still change this choice by configurating the specific parameters of this database. And in the welcome page of the base, you can still click on another flag to select another language. The present choice is therefore like a "default default" language.
 fr: Pour une base donnée, on peut encore changer ce choix en configurant les paramètres spécifiques à cette base de données. Et dans la page d’accueil d’une base de données, on peut encore cliquer sur un autre drapeau pour sélectionner une autre langue. Le choix présent est donc en quelque sorte la langue « par défaut par défaut ».
-co:
+co: Per una basa di dati particulare, si pò dinù cambià sta scelta cunfigurendu parametri specifichi à sta basa di dati. È nant’à a pagina d’accolta di a basa, si pò ancu sceglie un’altra bandera per selezziunà un’altra lingua. Quessa scelta hè dunque una specia di lingua « predefinita predefinita ».
 
     For a radical cleaning up, select your database by clicking on the associated button
 en: For a radical cleaning up, select your database by clicking on the associated button
 fr: Pour un nettoyage en profondeur, sélectionnez votre base de données en cliquant sur le bouton associé
-co:
+co: Per una nettata forte, selezziunate a vostra basa di dati clicchendu nant’à u buttone assuciatu
 
     For a simple cleaning up, apply the initialisation of consanguinities.
 en: For a simple cleaning up, apply the initialisation of consanguinities.
 fr: Pour un nettoyage simple, appliquez le programme d’initialisation des consanguinités.
-co:
+co: Per una nettata simplice, appiecate u prugramma d’iniziu di e cunsanguinità.
 
     For information
 en: For information
 fr: Pour information
-co:
+co: Per infurmazione
 
     For information, this operation corresponds to the following commands
 en: For information, this operation corresponds to the following commands
 fr: Pour information, cette opération correspond à la suite des opérations suivantes
-co:
+co: Per a vostra infurmazione, st’operazione currisponde à sta seguita di cumande :
 
     For these dates, extract only the "year" part.
 en: For these dates, extract only the "year" part.
 fr: Pour ces dates, n’extraire que la partie « année ».
-co:
+co: Per ste date, estraite solu a parte « annu ».
 
     Forbidden access
 en: Forbidden access
 fr: Accès interdit
-co:
+co: Accessu difesu
 
     Force relation status to "NoMention" (default is "Married").
 en: Force relation status to "NoMention" (default is "Married").
 fr: Marquer les relations comme « Sans mention » (par défaut « Mariés »).
-co:
+co: Marcà e rilazioni cum’è « Nisuna mensione » (u valore predefinitu hè « Maritati »).
 
     Go back to the previous page.
 en: Go back to the previous page.
 fr: Revenez à la page précédente.
-co:
+co: Rivinite à a pagina precedente.
 
     Go backward and select "reload" in your Web browser.
 en: Go backward and select "reload" in your Web browser.
 fr: Revenez en arrière et sélectionnez "actualiser" dans votre navigateur Web.
-co:
+co: Rivinite in daretu è selezziunate « Attualizà » in u vostru navigatore web.
 
     Go to your Web browser and open one of the following addresses:
 en: Go to your Web browser and open one of the following addresses:
 fr: Allez dans votre navigateur Web et ouvrez une des adresses suivantes:
-co:
+co: Andate in u vostru navigatore web è aprite unu di st’indirizzu :
 
     Gwfixbase messages
 en: Gwfixbase messages
 fr: Messages gwfixbase
-co:
+co: Messaghji gwfixbase
 
     help.
 en: help.
 fr: help.
-co:
+co: aiutu.
 
     Here are the deleted databases
 en: Here are the deleted databases
 fr: Voici les bases qui ont été détruites
-co:
+co: Eccu e base di dati chì sò state squassate
 
     Here are the parameters of the base "%a". Change what you estimate necessary
 en: Here are the parameters of the base "%a". Change what you estimate necessary
 fr: Voici les paramètres de la base "%a". Effectuez les modifications de votre choix
-co:
+co: Eccu i parametri di a basa « %a ». Fate i cambiamenti di a vostra scelta
 
     Here are the parameters of the command "gwd". Change the one you estimate necessary
 en: Here are the parameters of the command "gwd". Change the one you estimate necessary
 fr: Voici les paramètres de la commande "gwd". Vous pouvez modifier les paramètres suivants
-co:
+co: Eccu i parametri di a cumanda « gwd ». Cambiate ciò chì vi pare necessariu
 
     Here are the remaining databases
 en: Here are the remaining databases
 fr: Voici les bases qui restent
-co:
+co: Eccu e base di dati chì stanu
 
     Here are the traces of the command, maybe you can find an explanation
 en: Here are the traces of the command, maybe you can find an explanation
 fr: Voici les traces de la commande, peut-être y trouverez-vous une explication
-co:
+co: Eccu e traccie di a cumanda, forse ci truverete una spiegazione
 
     Here is an access to your database in order to test your parameters changing
 en: Here is an access to your database in order to test your parameters changing
 fr: Voici un accès à votre base pour tester vos changements de paramètres
-co:
+co: Eccu un accessu à a vostra basa di dati per pruvà i vostri cambiamenti di parametri
 
     Here is its contents
 en: Here is its contents
 fr: Voici son contenu
-co:
+co: Eccu u so cuntenutu
 
     Here is the contents of the file "comm.log"
 en: Here is the contents of the file "comm.log"
 fr: Voici le contenu du fichier "comm.log"
-co:
+co: Eccu u cuntenutu di u schedariu « comm.log »
 
     Hide advanced request.
 en: Hide advanced request.
 fr: Cacher la requête évoluée.
-co:
+co: Piattà a richiesta esperta
 
     Hide the names of the private persons, i.e. the still living persons or, more exactly, the persons of less than one century.
 en: Hide the names of the private persons, i.e. the still living persons or, more exactly, the persons of less than one century.
 fr: Cache les noms des personnes privées, c’est-à-dire les personnes vivantes, ou plus exactement, celles de moins de 100 ans.
-co:
+co: Piattà i nomi di e persone private, vale à dì e persone vive, o più precisamente, quelle di menu di 100 anni.
 
     Hide the private person's names.
 en: Hide the private person's names.
 fr: Cacher les noms des personnes privées.
-co:
+co: Piattà i nomi di e persone private.
 
     History of updates
 en: History of updates
 fr: Historique des mises à jour
-co:
+co: Cronolugia di e mudificazioni
 
     If "-" is selected, it is French.
 en: If "-" is selected, it is French.
 fr: Si c’est "-", c’est le français.
-co:
+co: S’è "-" hè selezziunatu, ghjè u francese.
 
     If do NOT want that your images are installed in the standard place (databases directory, sub-directory "images", sub-sub-directory "%a"), indicate here the path to the directory you want to use. This path is an URL: if it is a Web site, it must start with <tt>http://</tt>, if it is a local directory, it must start with <tt>file://</tt>. <p> This concerns the images which are indicated in the person form, field "image". This does not concern the images installed by the link "send image" which are installed as a standard name in a standard place.
 en: If do NOT want that your images are installed in the standard place (databases directory, sub-directory "images", sub-sub-directory "%a"), indicate here the path to the directory you want to use. This path is an URL: if it is a Web site, it must start with <tt>http://</tt>, if it is a local directory, it must start with <tt>file://</tt>. <p> This concerns the images which are indicated in the person form, field "image". This does not concern the images installed by the link "send image" which are installed as a standard name in a standard place.
 fr: Si vous désirez que vos images ne soient pas installées dans l’endroit standard (répertoire des bases, sous-répertoire "images", sous-sous-répertoire "%a"), indiquez ici le chemin d’accès au répertoire que vous voulez utiliser. Ce chemin d’accès est une URL : si c’est un site Web, il doit commencer par <tt>http://</tt>, si c’est un répertoire local, il doit commencer par <tt>file://</tt>. <p> Cela ne concerne que les images qui sont indiquées dans le formulaire des personnes, champ "image". Cela ne concerne pas les images installées par le lien "envoyer images" qui, elles, sont installées avec un nom standard dans le répertoire standard.
-co:
+co: S’è ùn vulete micca chì e vostre fiure sianu installate in u locu predefinitu (cartulare di e base, sottu-cartulare « images », sottu-sottu-cartulare « %a »), indicate quì u chjassu d’accessu à u cartulare chì vò vulete impiegà. Stu chjassu d’accessu hè un indirizzu URL : s’è ghjè un situ web, u chjassu deve principià da <tt>http://</tt> è in casu di cartulare lucale, u principiu serà <tt>file://</tt>. <p> Què hè vera solu per e fiure chì sò indicate in u campu « image » di u furmulariu di e persone; Ùn ghjova micca per e fiure installate da u liame « mandà fiure » chì, elle, sò installate cù un nome predefinitu in u cartulare predefinitu.
 
     If it is "-", the default language of the command "gwd" is applied.
 en: If it is "-", the default language of the command "gwd" is applied.
 fr: Si c’est "-", c’est la langue par défaut de la commande "gwd" qui sera prise.
-co:
+co: S’ella hè "-", ghjè a lingua predefinita di a cumanda « gwd » chì serà impiegata.
 
     If it is not the case, if, for example, some of them are just GEDCOM files or GeneWeb source files, return to the main menu to create them under %G, then go back to this page.
 en: If it is not the case, if, for example, some of them are just GEDCOM files or %G source files, return to the main menu to create them under %G, then go back to this page.
 fr: Si ce n’est pas le cas, si, par exemple, certaines d’entre elles sont sous forme GEDCOM ou fichiers source %G, revenez au menu principal pour les créer sous %G, puis revenez à cette page.
-co:
+co: S’è ùn hè micca u casu, per indettu, s’è certe trà elle sò in u furmatu GEDCOM o schedarii di fonte %G, rivinite à u listinu principale per crealle cù %G, è tandu rivinite à sta pagina.
 
     If it is, try the address below. The displayed page is called "welcome page" of your database. Bookmark it.
 en: If it is, try the address below. The displayed page is called "welcome page" of your database. Bookmark it.
 fr: Vous pourrez ensuite accéder à votre généalogie en suivant le lien ce-dessous. Vous pouvez l’ajouter aux signets de votre  navigateur.
-co:
+co: Tandu, puderete accede à a vostra genealugia cù u liame quaghjò. A pagina affissata hè l’accolta di a vostra basa. Vi ricumandemu d’aghjunghjela à l’indette di u vostru navigatore.
 
     If none of theses addresses work, you may have to configure, in your browser, options like "work off-line" or "do not use the proxy for local addresses" or "do not connect to Internet for the address 'localhost'".
 en: If none of theses addresses work, you may have to configure, in your browser, options like "work off-line" or "do not use the proxy for local addresses" or "do not connect to Internet for the address 'localhost'".
 fr: Si aucune de ces adresses ne fonctionne, il se peut que vous ayez à configurer dans votre navigateur des options du genre "travailler hors connexion" ou "ne pas utiliser de proxy pour les adresses locales" ou "ne pas se connecter sur internet pour l'adresse 'localhost'".
-co:
+co: S’è alcunu di st’indirizzi funziuneghja, forse ci vulerà à cunfigurà in u vostru navigatore qualchì ozzione di u tipu « travaglià fora di cunnessione » o « ùn impiegà micca u proxy per l’indirizzi lucale » o « ùn micca cunnettassi à Internet per l’indirizzu 'localhost' »
 
     If this area is empty, everybody is a "friend". You can leave this area empty if your computer is not accessible from outside.
 en: If this area is empty, everybody is a "friend". You can leave this area empty if your computer is not accessible from outside.
 fr: Si cette zone est vide, tout le monde est "ami". Vous pouvez laisser cette zone vide si votre ordinateur n’est pas accessible de l’extérieur.
-co:
+co: S’è st’aghja hè viota, tutti sò « amichi ». Pudete lascià viota st’aghja s’è u vostru urdinatore ùn hè micca accessibile da fora.
 
     If this area is empty, everybody is a "wizard". You can leave this area empty if your computer is not accessible from outside.
 en: If this area is empty, everybody is a "wizard". You can leave this area empty if your computer is not accessible from outside.
 fr: Si cette zone est vide, tout le monde est "magicien". Vous pouvez laisser cette zone vide si votre ordinateur n’est pas accessible de l’extérieur.
-co:
+co: S’è st’aghja hè viota, tutti sò « maghi ». Pudete lascià viota st’aghja s’è u vostru urdinatore ùn hè micca accessibile da fora.
 
     If this area is empty, the database has not been renamed.
 en: If this area is empty, the database has not been renamed.
 fr: Si cette zone est vide, la base n’est pas renommée.
-co:
+co: S’è st’aghja hè viota, a basa di dati ùn hè micca stata rinuminata.
 
     If yes, the "wizards" are authorized to upload images.
 en: If yes, the "wizards" are authorized to upload images.
 fr: Si oui, les "magiciens" ont l’autorisation d’envoyer des images par le réseau.
-co:
+co: S’ella hè vera, i « maghi » sò auturizati à mandà fiure via a reta.
 
     If yes, the "wizards" loose their power to make updates.
 en: If yes, the "wizards" loose their power to make updates.
 fr: Si oui, les "magiciens" perdent leur pouvoir de mise-à-jour.
-co:
+co: S’ella hè vera, i « maghi » perdenu u so putere di mudificazione.
 
     If you changed the name of your database, but this database has been existed since a long time and you think that many people made links to it, keep this parameter file for this base and write here the new name of the database. People who consult the database with the old name receive then a page indicating them the new name to use with the same clickable request.
 en: If you changed the name of your database, but this database has been existed since a long time and you think that many people made links to it, keep this parameter file for this base and write here the new name of the database. People who consult the database with the old name receive then a page indicating them the new name to use with the same clickable request.
 fr: Si vous avez changé le nom de votre base, mais que c’est une base qui existe depuis longtemps et que vous pensez que beaucoup de gens ont mis des liens dessus, conservez ce fichier de paramètres pour cette base et indiquez ci-dessous le nouveau nom de la base. Les gens qui consulteront la base avec l’ancien nom recevront une page qui leur indiquera le nouveau nom à utiliser avec leur même requête cliquable.
-co:
+co: S’è vò avete cambiatu u nome di a vostra basa di dati, ma chì ghjè una basa chì esiste dapoi un pezzu, è chì vò pensate chì tamanta ghjente ci hà messu liami annantu, cunservate stu schedariu di parametri per sta basa è indicate quaghjò u novu nome di a basa. A ghjente chì cunsulterà a basa di dati cù u vechju nome riceverà una pagina chì ci indicherà u novu nome à impiegà cù a so stessa richiesta clicchevule.
 
     If you gave a text to put in the bottom of the pages, this text is recorded in the file named "%a.trl" in the subdirectory "lang" of the directory "%w".
 en: If you gave a text to put in the bottom of the pages, this text is recorded in the file named "%a.trl" in the subdirectory "lang" of the directory "%w".
 fr: Si vous avez donné un texte à mettre au bas des pages, ce texte est enregistré dans la fichier de nom "%a.trl" dans le sous-répertoire "lang" du répertoire "%w".
-co:
+co: S’è vò avete datu un testu à piazzà à u bassu di e pagine, stu testu serà arregistratu in u schedariu di nome « %a.trl » in u sottu-cartulare « lang » di u cartulare « %w ».
 
     If you just made this, it is probably its result, and therefore it is not important. Else, return to the previous page and choose another name for your database.
 en: If you just made this, it is probably its result, and therefore it is not important. Else, return to the previous page and choose another name for your database.
 fr: Si vous venez déjà de faire cette manipulation, il s’agit probablement de son résultat, ce n’est donc pas grave. Sinon, revenez en arrière et choisissez un autre nom pour votre base.
-co:
+co: S’è vò avete dighjà fattu st’azzione, forse ghjè u so risultatu, è dunque ùn hè micca impurtante. Osinnò, rivinite à a pagina precedente è sciglite un altru nome per a vostra basa.
 
     If you made many modifications in your database, or if you simply entered much data, it is advised to make a cleaning up, especially if you observe that the access to your database has slowed down.
 en: If you made many modifications in your database, or if you simply entered much data, it is advised to make a cleaning up, especially if you observe that the access to your database has slowed down.
 fr: Si vous avez fait beaucoup de modifications dans votre base de données, ou si vous avez simplement entré beaucoup de données, il est conseillé de faire un nettoyage, surtout si vous constatez que l’accès à votre base de données commence à ralentir.
-co:
+co: S’è vò avete fattu mudificazioni numerose in a vostra basa di dati, o avete aghjuntu dati numerosi, hè ricumandatu di fà una nettata, soprattuttu s’è l’accessu à a vostra basa di dati si face avà pianu pianu.
 
     If you use both above options, the intersection is assumed:<br> persons <em>at the same time</em> ancestors of the one and descendants of the other.
 en: If you use both above options, the intersection is assumed:<br> persons <em>at the same time</em> ancestors of the one and descendants of the other.
 fr: Si vous utilisez les deux options ci-dessus, c’est l’intersection qui comptera :<br>personnes <em>à la fois</em> ancêtres de l’un et descendants de l’autre.
-co:
+co: S’è vò impiegate e duie ozzioni inzù, ghjè l’intersezzione chì supranerà :<br> persone <em>à u listessu tempu</em> antenati di l’una è discendenti di l’altra.
 
     If you use both options above, the intersection is assumed: persons <em>at the same time</em> ancestors of the one and descendants of the other.
 en: If you use both options above, the intersection is assumed: persons <em>at the same time</em> ancestors of the one and descendants of the other.
 fr: Si vous utilisez les deux options ci-dessus, c’est l’intersection qui comptera: personnes <em>à la fois</em> ancêtres de l’un et descendants de l’autre.
-co:
+co: S’è vò impiegate e duie ozzioni inzù, ghjè l’intersezzione chì supranerà : persone <em>à u listessu tempu</em> antenati di l’una è discendenti di l’altra.
 
     If you want that a text appears in the bottom of each page, write it here. You can use HTML tags.
 en: If you want that a text appears in the bottom of each page, write it here. You can use HTML tags.
 fr: Si vous voulez qu’un texte apparaisse au bas de chaque page, indiquez-le ici. Vous pouvez y mettre des balises HTML.
-co:
+co: S’è vo vulete chì un testu sia scrittu à u bassu d’ogni pagina, scrivitelu puru quì. Pudete metteci dentru etichette HTML.
 
     If you want that the traces rather go in a file, write here the name of the file here. This file will be created if it does not exist, in the main directory of %G where you see the commands "gwsetup" and "gwd". It will be extended at each request.
 en: If you want that the traces rather go in a file, write here the name of the file here. This file will be created if it does not exist, in the main directory of %G where you see the commands "gwsetup" and "gwd". It will be extended at each request.
 fr: Si vous désirez que les traces aillent plutôt dans un fichier, indiquez ici le nom du fichier que vous désirez. Ce fichier sera créé, s’il n’existe pas, dans le répertoire principal de %G où vous voyez les commandes "gwsetup" et "gwd". Il sera rallongé à chaque requête.
-co:
+co: S’è vo vulete piuttostu chì e traccie vochinu in un schedariu, scrivite quì u so nome. Stu schedariu serà creatu, s’ellu ùn esiste, in u cartulare principale di %G induve si trovanu e cumande « gwsetup » è « gwd ». È serà allungatu à ogni richiesta.
 
     If you were already doing that, and it does not work better, ask the creator of the %G program. Send him the traces of the command.
 en: If you were already doing that, and it does not work better, ask the creator of the %G program. Send him the traces of the command.
 fr: Si c’est précisément ce que vous venez de faire et que ça ne marche donc pas, demandez conseil au créateur du programme %G en lui envoyant les traces de la commande.
-co:
+co: S’ella hè ciò chì vò avete dighjà fattu, è chì ùn funziuneghja sempre micca bè, dumandate l’aiutu di u sviluppatore di %G. Ci vole à mandallu e traccie di a cumanda.
 
     If you write nothing, it will be deducted from the GeneWeb source file.
 en: If you write nothing, it will be deducted from the %G source file.
 fr: Si vous ne mettez rien, il sera déduit du nom du fichier source %G.
-co:
+co: S’è ùn scrivite nunda, serà deduttu secondu u nome di u schedariu di fonte %G.
 
     Ignore this file.
 en: Ignore this file.
 fr: Ignorer ce fichier.
-co:
+co: Ignurà stu schedariu.
 
     Images path
 en: Images path
 fr: Chemin d’accès aux images
-co:
+co: Chjassu d’accessu à e fiure
 
     Import a GEDCOM file
 en: Import a GEDCOM file
 fr: Importation d’un fichier GEDCOM
-co:
+co: Impurtazione d’un schedariu GEDCOM
 
     Import a GeneWeb file
 en: Import a %G file
 fr: Importation d’un fichier %G
-co:
+co: Impurtazione d’un schedariu %G
 
     In order to take the parameters into account, the gwd service must be stopped, if it was running, and restarted.
 en: In order to take the parameters into account, the gwd service must be stopped, if it was running, and restarted.
 fr: Pour que les paramètres soient pris en compte, il faut arrêter le service gwd, s’il tourne, et le relancer.
-co:
+co: Per chì i parametri sianu pigliati in contu, ci vole à piantà u serviziu gwd - s’ellu funziuneghja - è rilanciallu.
 
     In the boxes below, always enter a value in the Num entry (occurence) ("0" possibly).
 en: In the boxes below, always enter a value in the Num entry (occurence) ("0" possibly).
 fr: Dans les cadres ci-dessous, toujours fournir une occurence pour le champs "Num" (éventuellement "0").
-co:
+co: In e scatule quaghjò, ci vole à scrive sempre un’occurrenza per u campu « Num » (eventualmente « 0 »).
 
     Incorrect name
 en: Incorrect name
 fr: Nom incorrect
-co:
+co: Nome incurrettu
 
     Indeed, the navigation by "gwsetup" is mainly destinated to make the use of %G simpler, but does not allow to exploit quite all the possibilities. To find the other parameters and their use, you must be a little bit "hacker": some informations can be found in the documentation.
 en: Indeed, the navigation by "gwsetup" is mainly destinated to make the use of %G simpler, but does not allow to exploit quite all the possibilities. To find the other parameters and their use, you must be a little bit "hacker": some informations can be found in the documentation.
 fr: En effet, la navigation par "gwsetup" est principalement destinée à rendre plus simple l’utilisation de %G, mais ne permet pas d’en exploiter tout à fait toutes les possibilités. Pour trouver les autres paramètres et leur usage, il faut être un peu « bricoleur » : quelques informations peuvent être trouvées en cherchant dans la documentation.
-co:
+co: Difatti, a navigazione cù « gwsetup » hè soprattuttu fatta per rende più faciule l’impiegu di %G, ma ùn permette micca di sfruttane tutte e pussibilità. Per truvà l’altri parametri è u so impiegu, ci vole una cria à scumbatticcià : si pò truvà certe infurmazioni in a documentazione.
 
     index. Automatically enabled by any other option
 en: index. Automatically enabled by any other option
 fr: index. Activé automatiquement par les autres options
-co:
+co: Indice. Attivatu autumaticamente da l’altre ozzioni
 
     Indicate the name you want to give to your resulting database:
 en: Indicate the name you want to give to your resulting database:
 fr: Indiquez le nom que vous voulez donner à votre base de données résultante:
-co:
+co: Scrivite u nome chì vò vulete dà à a vostra basa di dati risultante :
 
     Information: the parameters are recorded in a text file named "gwd.arg" in the directory "gw" of your %G distribution.
 en: Information: the parameters are recorded in a text file named "gwd.arg" in the directory "gw" of your %G distribution.
 fr: Information : les paramètres sont enregistrés dans le fichier texte "gwd.arg" qui se trouve dans le répertoire "gw" de votre distribution %G.
-co:
+co: Infurmazione : i parametri sò arregistrati in u schedariu di testu chì si chjama « gwd.arg » in u cartulare « gw » di a distribuzione %G.
 
     Interpret these dates as "day/month/year".
 en: Interpret these dates as "day/month/year".
 fr: Interpréter ces dates comme « jour/mois/année ».
-co:
+co: Interpretà ste date cum’è « ghjornu/mese/annu ».
 
     Interpret these dates as "month/day/year".
 en: Interpret these dates as "month/day/year".
 fr: Interpréter ces dates comme « mois/jour/année ».
-co:
+co: Interpretà ste date cum’è « mese/ghjornu/annu ».
 
     It is not possible to execute your command. You did not give enough information.
 en: It is not possible to execute your command. You did not give enough information.
 fr: Il n’est pas possible d’exécuter votre commande. Vous n’avez pas donné assez d’informations.
-co:
+co: Ùn hè micca pussibule d’eseguisce sta cumanda. Ùn avete micca datu abbastanza infurmazioni.
 
     links color
 en: links color
 fr: couleur des liens
-co:
+co: culore di i liami
 
     Listing connected components
 en: Listing connected components
 fr: Liste des composantes connexes
-co:
+co: Lista di i cumpunenti cunnessi
 
     Look at the traces, may be you can find an explanation.
 en: Look at the traces, may be you can find an explanation.
 fr: Consultez les traces, vous y trouverez probablement une explication.
-co:
+co: Fighjate e traccie, forse ci truverete una spiegazione.
 
     Look at the traces, maybe you can find an explanation.
 en: Look at the traces, maybe you can find an explanation.
 fr: Regardez dans les traces, peut-être y trouverez-vous une explication.
-co:
+co: Fighjate e traccie, forse ci truverete una spiegazione.
 
     Main menu
 en: Main menu
 fr: Menu principal
-co:
+co: Listinu principale
 
     marriage divorce.
 en: marriage divorce.
 fr: marriage divorce.
-co:
+co: divorziu - matrimoniu.
 
     Maximum level when displaying ancestors by tree.
 en: Maximum level when displaying ancestors by tree.
 fr: Niveau maximum dans l’affichage des ascendants par arbre.
-co:
+co: Livellu massimu à l’arburu per l’affissera di l’antenati.
 
     Maximum level when displaying ancestors.
 en: Maximum level when displaying ancestors.
 fr: Niveau maximum dans l’affichage des ascendants.
-co:
+co: Livellu massimu per l’affissera di l’antenati.
 
     Maximum level when displaying descendants by tree.
 en: Maximum level when displaying descendants by tree.
 fr: Niveau maximum dans l’affichage des descendants par arbre.
-co:
+co: Livellu massimu à l’arburu per l’affissera di i discendenti.
 
     Maximum level when displaying descendants.
 en: Maximum level when displaying descendants.
 fr: Niveau maximum dans l’affichage des descendants.
-co:
+co: Livellu massimu per l’affissera di i discendenti.
 
     Merge
 en: Merge
 fr: Fusionner
-co:
+co: Fusione
 
     Merging databases
 en: Merging databases
 fr: Fusion de bases de données
-co:
+co: Fusione di base di dati
 
     Missing name
 en: Missing name
 fr: Nom manquant
-co:
+co: Nome assente
 
     name
 en: name
 fr: nom
-co:
+co: nome
 
     No consistency check.
 en: No consistency check.
 fr: Ne pas contrôler la cohérence des données.
-co:
+co: Ùn micca verificà a cuerenza di i dati.
 
     No negative dates: do not interpret a year preceded by a minus sign as a negative year.
 en: No negative dates: do not interpret a year preceded by a minus sign as a negative year.
 fr: Pas de dates négatives : ne pas interpréter une année précédée du signe moins « - » comme une date négative.
-co:
+co: Senza data nigativa : ùn micca interpretà un annu precidutu da un segnu menu « - » cum’è una data nigativa.
 
     No redirection of results.
 en: No redirection of results.
 fr: Pas de redirection des résultats.
-co:
+co: Alcuna ridirezzione di i risultati.
 
     no selection
 en: no selection
 fr: pas de sélection
-co:
+co: nisuna selezzione
 
     no traces
 en: no traces
 fr: pas de traces
-co:
+co: nisuna traccia
 
     Not public even if titles (see -epn option).
 en: Not public even if titles (see -epn option).
 fr: Ne pas considérer comme public si un titre a été détecté (voir option -epn).
-co:
+co: Ùn micca cunsiderà cum’è publicu s’è un titulu hè statu abbentatu (fighjà l’ozzione -epn).
 
     Note
 en: Note
 fr: Note
-co:
+co: Nota
 
     Num
 en: Num
 fr: Num
-co:
+co: Num
 
     Once done, select the databases you want to merge by pushing their associated buttons:
 en: Once done, select the databases you want to merge by pushing their associated buttons:
 fr: Une fois fait, sélectionnez les bases que vous voulez fusionner en cliquant sur leur bouton associé:
-co:
+co: Quandu hè fattu, selezziunate e base di dati ch’ellu ci vole à unisce clicchendu nant’à u so buttone assuciatu :
 
     Only authorized address.
 en: Only authorized address.
 fr: Seule adresse autorisée.
-co:
+co: Solu indirizzu auturizatu.
 
     Only the requests from this Internet address are accepted.
 en: Only the requests from this Internet address are accepted.
 fr: Seules les requêtes provenant de cette adresse Internet seront acceptées.
-co:
+co: Solu e richieste pruvinendu da st’indirizzu internet seranu accettate.
 
     Operation completed
 en: Operation completed
 fr: Opération terminée
-co:
+co: Operazione compia
 
     or ask for recreation of files in original directory.<br> If the base was created by <span style="font-family: monospace">gwc -f *.gw</span>,  then <span style="font-family: monospace">gwu -odir .</span> will recreate the source files.
 en: or ask for recreation of files in original directory.<br> If the base was created by <span style="font-family: monospace">gwc -f *.gw</span>,  then <span style="font-family: monospace">gwu -odir .</span> will recreate the source files.
 fr: ou demandez à reconstruire les fichiers dans le dossier d'origine.<br> Si la base a été créé par <span style="font-family: monospace">gwc -f *.gw</span>, alors <span style="font-family: monospace">gwu -odir .</span> reconstruira les fichiers d'origine.
-co:
+co: o dumandate à ricustruisce i schedarii in u cartulare d’origine.<br> S’è a basa hè stata creata da <span style="font-family: monospace">gwc -f *.gw</span>, tandu <span style="font-family: monospace">gwu -odir .</span> ricustruiscerà i schedarii d’origine.
 
     Or else, it may be a very old version of %G where the command "gwu" was called "gwb2gw". If it is the case, rename the file "gwb2gw" into "gwu" in this directory and try again.
 en: Or else, it may be a very old version of %G where the command "gwu" was called "gwb2gw". If it is the case, rename the file "gwb2gw" into "gwu" in this directory and try again.
 fr: Il se peut également qu’il s’agisse d’une très ancienne version de %G dans laquelle la commande "gwu" s’appelait "gwb2gw". Si c’est le cas, renommez le fichier "gwb2gw" en "gwu" dans ce répertoire et réessayez.
-co:
+co: Osinnò, forse hè una versione à l’anticogna di %G quandu a cumanda « gwu » si chjamava « gwb2gw ». In tale casu, rinuminate u schedariu « gwb2gw » in « gwu » in stu cartulare è pruvate torna.
 
     Or go back to the main menu.
 en: Or go back to the main menu.
 fr: Ou revenez au menu principal.
-co:
+co: O rivinite à u listinu principale.
 
     or provide directly the name of the GeneWeb source file(s) relative to the path above.<br> If this parameter contains the '*' character, you must provide a unique name for created database.
 en: or provide directly the name of the GeneWeb source file(s) relative to the path above.<br> If this parameter contains the '*' character, you must provide a unique name for created database.
 fr: ou donnez directement le nom du ou des fichiers source GeneWeb en complément du chemin ci-dessus.<br> Si ce paramètre contient le caractère '*', il sera impératif de fournir un nom unique pour la base qui sera créée.
-co:
+co: o scrivite puru u nome di u o di i schedarii di fonte GeneWeb relativamente à u chjassu inzù.<br> S’è stu parametru cuntene u caratteru « * », ci vulerà à pruvede un nome unicu per a basa di dati chì serà creata.
 
     Other parameters exist for the command "gwd", but are not configurable here because they can perturbate the operation of "gwsetup".
 en: Other parameters exist for the command "gwd", but are not configurable here because they can perturbate the operation of "gwsetup".
 fr: D’autres paramètres existent pour la commande "gwd", mais ils ne sont pas configurables ici, car ils peuvent perturber le fonctionnement de "gwsetup".
-co:
+co: D’altri parametri esistenu per a cumanda « gwd », ma ùn ponu micca esse cunfigurati quì, perchè elli ponu disturbà u funziunamentu di « gwsetup ».
 
     Output results in basename/notes_d/connex.txt (-o must stay empty and notes_d must exist).
 en: Output results in basename/notes_d/connex.txt (-o must stay empty and notes_d must exist).
 fr: Redirige le résultat vers basename/notes_d/connex.txt (-o doit rester vide et notes_d doit exister).
-co:
+co: Inversureghja i risultati ver di basename/notes_d/connex.txt (-o deve stà viotu è notes_d deve esiste).
 
     Output results to this file.
 en: Output results to this file.
 fr: Rediriger les résultats vers ce fichier.
-co:
+co: Inversureghja i risultati ver di stu schedariu.
 
     Page outdated
 en: Page outdated
 fr: Page non à jour
-co:
+co: Pagina antica à rinnovà
 
     Parameters
 en: Parameters
 fr: Paramètres
-co:
+co: Parametri
 
     Parameters "%a"
 en: Parameters "%a"
 fr: Paramètres "%a"
-co:
+co: Parametri « %a »
 
     Parameters for "gwd"
 en: Parameters for "gwd"
 fr: Paramétrage de gwd
-co:
+co: Parametri di « gwd »
 
     Parameters updated
 en: Parameters updated
 fr: Paramètres mis à jour
-co:
+co: Parametri mudificati
 
     Pass by a GEDCOM file. A priori, it is not recommended, but if it does not work with the normal procedure, try this option.
 en: Pass by a GEDCOM file. A priori, it is not recommended, but if it does not work with the normal procedure, try this option.
 fr: Passer par un fichier GEDCOM. A priori, c’est déconseillé, mais si ça ne fonctionne pas avec la procédure normale,  essayez cette option.
-co:
+co: Passate da un schedariu GEDCOM. Da regula, st’azzione ùn hè micca ricumandata ; ci vole à pruvalla solu quandu a prucedura nurmale ùn funziuneghja micca.
 
     Password for "friends".
 en: Password for "friends".
 fr: Mot de passe "ami".
-co:
+co: Parolla d’entrata « amicu »
 
     Password for "Wizards".
 en: Password for "Wizards".
 fr: Mot de passe "magicien".
-co:
+co: Parolla d’entrata « magu »
 
     persons' families.
 en: persons' families.
 fr: persons' families.
-co:
+co: famiglie - persone.
 
     persons' NBDS.
 en: persons' NBDS.
 fr: persons' NBDS.
-co:
+co: NBDS - persone.
 
     persons' parents.
 en: persons' parents.
 fr: persons' parents.
-co:
+co: genitori - persone.
 
     pevents' witnesses.
 en: pevents' witnesses.
 fr: pevents' witnesses.
-co:
+co: testimoni - « pevents ».
 
     Produce connected components statistics.
 en: Produce connected components statistics.
 fr: Afficher les statistiques sur les composantes connexes.
-co:
+co: Affissà e statistiche nant’à i cumpunenti cunnessi.
 
     Push the below button to launch the operation
 en: Push the below button to launch the operation
 fr: Appuyez sur le bouton ci-dessous pour lancer l’opération
-co:
+co: Primete nant’à u buttone quaghjò per lancià l’operazione.
 
     Push the button below to create you database
 en: Push the button below to create you database
 fr: Appuyez sur Ok pour créer votre généalogie
-co:
+co: Primete nant’à « Vai » per creà a vostra genealugia
 
     Push the button below to create your database
 en: Push the button below to create your database
 fr: Appuyez sur le bouton ci-dessous pour créer votre base de données
-co:
+co: Primete nant’à u buttone quaghjò per creà a vostra basa di dati
 
     Push this button to start
 en: Push the button to start
 fr: Appuyez sur le bouton pour démarrer
-co:
+co: Primete nant’à u buttone per principià
 
     Put the image file in the directory (possibly create it before):
 en: Put the image file in the directory (possibly create it before):
 fr: Mettez ce fichier image dans le répertoire (que vous devrez éventuellement créer):
-co:
+co: Piazzate u schedariu di a fiura in u cartulare (chì vò duverete forse creà) :
 
     Put untreated GEDCOM tags in notes.
 en: Put untreated GEDCOM tags in notes.
 fr: Sauvegarder les tags GEDCOM non reconnus dans les notes.
-co:
+co: Arregistrate in e note l’etichette GEDCOM scunnisciute.
 
     quiet mode.
 en: quiet mode.
 fr: peu de traces.
-co:
+co: poche traccie.
 
     Read the alert messages in the file "comm.log"
 en: Read the alert messages in the file "comm.log"
 fr: Consulter les messages d’alerte dans le fichier "comm.log"
-co:
+co: Fighjà i messaghji d’alerta in u schedariu « comm.log »
 
     Recover
 en: Recover
 fr: Récupérer
-co:
+co: Ricuperà
 
     Recover a database
 en: Recover a database
 fr: Récupérer une base
-co:
+co: Ricuperà una basa di dati
 
     Recover a database - Phase 1
 en: Recover a database - Phase 1
 fr: Récupérer une base - Phase 1
-co:
+co: Ricuperà una basa di dati - Fasa 1
 
     Recover a database - Phase 2
 en: Recover a database - Phase 2
 fr: Récupérer une base - Phase 2
-co:
+co: Ricuperà una basa di dati - Fasa 2
 
     Recover a database - Phase 3
 en: Recover a database - Phase 3
 fr: Récupérer une base - Phase 3
-co:
+co: Ricuperà una basa di dati - Fasa 3
 
     Remark: merging consists on simple concatenation of the databases. There is no research for identical persons. After merging, you therefore have to research the possible doubled persons or families and merge them. See the documentation.
 en: Remark: merging consists on simple concatenation of the databases. There is no research for identical persons. After merging, you therefore have to research the possible doubled persons or families and merge them. See the documentation.
 fr: Remarque : la fusion consiste en la simple concaténation des bases de données. Il n’y a pas de recherche de personnes identiques. Après la fusion, il faudra donc rechercher les éventuelles personnes et familles en double et les fusionner. Voir la documentation.
-co:
+co: Rimarca : a fusione hè solu u cuncatinamentu simplice di e base di dati. Ùn ci hè micca ricerca di persone identiche. Dopu a fusione, duverete circà e persone o e famiglie in doppiu è uniscele. Per què, fighjate a documentazione.
 
     Remark: this operation can answer in the twinkling of a eye or take some tenths of seconds or some minutes, depending on the cases. Be patient.
 en: Remark: this operation can answer in the twinkling of a eye or take some tenths of seconds or some minutes, depending on the cases. Be patient.
 fr: Remarque : cette opération peut s’effectuer en un clin d’oeil ou prendre quelques dizaines de secondes ou quelques minutes, suivant les cas. Soyez patient.
-co:
+co: Rimarca : st’operazione pò fassi in furia o piglià qualchì decine di seconda o parechji minuti secondu à u casu. Aspettate per piacè.
 
     Rename
 en: Rename
 fr: Renommer
-co:
+co: Rinuminà
 
     replacing "<tt>foo.jpg</tt>" by the real name of your image file.
 en: replacing "<tt>foo.jpg</tt>" by the real name of your image file.
 fr: en remplaçant "<tt>toto.jpg</tt>" par le vrai nom de votre fichier image.
-co:
+co: rimpiazzendu « <tt>fiura.jpg</tt> » da u veru nome di schedariu di a fiura.
 
     Restart the computing from scratch.
 en: Restart the computing from scratch.
 fr: Recommencer le calcul sur toute la base.
-co:
+co: Riprincipià u calculu nant’à a basa sana.
 
     Restrict deleting branches whose size = -del.
 en: Restrict deleting branches whose size = -del.
 fr: Limite la suppression aux branches de taille = -del.
-co:
+co: Limiteghja a squassatura à e ghjembe di dimensione = -del.
 
     Return to the main menu.
 en: Return to the main menu.
 fr: Revenez au menu principal.
-co:
+co: Rivinite à u listinu principale.
 
     Return to the previous page and select the correct file.
 en: Return to the previous page and select the correct file.
 fr: Revenez en arrière et sélectionnez le bon fichier.
-co:
+co: Rivinite à a pagina precedente è selezziunate u schedariu currettu.
 
     Return to the previous screen and write the good directory.
 en: Return to the previous screen and write the good directory.
 fr: Revenez à l’écran précédent et indiquez le bon répertoire.
-co:
+co: Rivinite à u screnu precedente è indicate u cartulare currettu.
 
     Save and Restore
 en: Save and Restore
 fr: Sauvegarde et restauration
-co:
+co: Arregistramentu è risturazione
 
     Save memory space during operation (but it will be slower).
 en: Save memory space during operation (but it will be slower).
 fr: Économiser l’espace mémoire pendant l’opération (mais ce sera plus lent).
-co:
+co: Risparmià u spaziu di memoria durante l’operazione (ma anderà più pianu).
 
     Save the memory space during the operation (but it will be slower).
 en: Save the memory space during the operation (but it will be slower).
 fr: Économiser l’espace mémoire pendant l’opération (mais ce sera plus lent).
-co:
+co: Risparmià u spaziu di memoria durante l’operazione (ma anderà più pianu).
 
     Search
 en: Search
 fr: Chercher
-co:
+co: Ricercà
 
     Select the database or databases you want to delete, by clicking on the associated buttons.
 en: Select the database or databases you want to delete, by clicking on the associated buttons.
 fr: Sélectionnez la ou les bases que vous voulez détruire en cliquant sur le ou les boutons associés:
-co:
+co: Selezziunate a basa o e base di dati ch’ellu ci vole à squassà clicchendu nant’à u so buttone assuciatu.
 
     Select the database you want to recover
 en: Select the database you want to recover
 fr: Sélectionnez la base que vous voulez récupérer
-co:
+co: Selezziunate a basa di dati ch’ellu ci vole à ricuperà
 
     Select the name of the <em>directory</em> where your old version of %G is located (it must contain a filen named <tt>gwu</tt> or <tt>gwu.exe</tt>).
 en: Select the name of the <em>directory</em> where your old version of %G is located (it must contain a filen named <tt>gwu</tt> or <tt>gwu.exe</tt>).
 fr: Sélectionnez le <em>répertoire</em> où se trouve votre ancienne version de %G (il doit contenir un fichier nommé <tt>gwu</tt> ou <tt>gwu.exe</tt>).
-co:
+co: Selezziunate u nome di u <em>cartulare</em> induve si trova a vostra vechja versione di %G (chì deve cuntene un schedariu chjamatu <tt>gwu</tt> o <tt>gwu.exe</tt>).
 
     Select the name of your GeneWeb source file (ending with ".gw");
 en: Select the name of your %G source file (ending with ".gw");
 fr: Sélectionnnez votre fichier source %G (se terminant par ".gw"):
-co:
+co: Selezziunate u vostru schedariu di fonte %G (finischendu da « .gw ») :
 
     Select the options you want
 en: Select the options you want
 fr: Sélectionnez les options que vous désirez
-co:
+co: Selezziunate l’ozzioni chì vò vulete
 
     Select the source file or navigate in your folders.
 en: Select the source file or navigate in your folders.
 fr: Sélectionnez le nom du fichier source, ou naviguez dans vos dossiers.
-co:
+co: Selezziunate u nome di u schedariu di fonte, o navigate in i vostri cartulari.
 
     Select the source file or navigate in your foldres.
 en: Select the source file or navigate in your foldres.
 fr: Sélectionnez le nom du fichier source, ou naviguez dans vos dossiers.
-co:
+co: Selezziunate u nome di u schedariu di fonte, o navigate in i vostri cartulari.
 
     Select your database by clicking on the associated button
 en: Select your database by clicking on the corresponding button
 fr: Sélectionnez votre base de données en cliquant sur le bouton associé
-co:
+co: Selezziunate a vostra basa di dati clicchendu nant’à u buttone assuciatu
 
     Select your first database
 en: Select your first database
 fr: Sélectionnez la première base de données 
-co:
+co: Selezziunate a prima basa di dati
 
     Select your GEDCOM file by clicking on the file or navigating in your folders.
 en: Select your GEDCOM file by clicking on the file or navigating in your folders.
 fr: Sélectionnez votre fichier GEDCOM en cliquant sur son nom ou en navigant dans les dossiers.
-co:
+co: Selezziunate u vostru schedariu GEDCOM clicchendu nant’à u so nome, o navigate in i vostri cartulari.
 
     Select your second database
 en: Select your second database
 fr: Sélectionnez la seconde base de données
-co:
+co: Selezziunate a seconda basa di dati
 
     Service gwd
 en: Service gwd
 fr: Service gwd
-co:
+co: Serviziu gwd
 
     Set negative dates when inconsistency (e.g. birth after death).
 en: Set negative dates when inconsistency (e.g. birth after death).
 fr: Essayer de mettre des dates négatives s’il y a incohérence (exemple : naissance après la mort).
-co:
+co: Pruvà di mette date nigative quandu ùn ci hè micca cuerenza (esempiu : nascita dopu a morta).
 
     Set this option.
 en: Set this option.
 fr: Activer cette option.
-co:
+co: Attivà st’ozzione.
 
     Simple method
 en: Simple method
 fr: Méthode simple
-co:
+co: Metoda simplice
 
     Some GEDCOM files sometimes write dates with numbered months (from 1 to 12). The GEDCOM standard 5.5 requires that the months be represented by identifiers (e.g. "MAY 1912" and not "05/1912"). The notation "02/05/1912" is ambiguous (means "May 2, 1912" or "February 5, 1912" according to the countries).
 en: Some GEDCOM files sometimes write dates with numbered months (from 1 to 12). The GEDCOM standard 5.5 requires that the months be represented by identifiers (e.g. "MAY 1912" and not "05/1912"). The notation "02/05/1912" is ambiguous (means "May 2, 1912" or "February 5, 1912" according to the countries).
 fr: Certains fichiers GEDCOM écrivent parfois les dates en mettant les mois avec des nombres (de 1 à 12). Le standard GEDCOM 5.5 exige que les mois soient représentés par des identificateurs (ex. : « MAI 1912 » et non pas « 05/1912 »). La notation « 02/05/1912 » est ambiguë : elle peut signifier « 2 mai 1912 » ou « 5 février 1912 » suivant les pays.
-co:
+co: Certi schedarii GEDCOM scrivenu ognitantu e date cù numeri (da 1 à 12) per i mesi. A norma GEDCOM 5.5 richiede chì i mesi sianu riprisentati da parolle (esempiu : « MAGHJU 1912 » è micca « 05/1912 »). A scrittura « 02/05/1912 » hè ambigua (vole dì « 2 di maghju di u 1912 » o « 5 di ferraghju di u 1912 » secondu i paesi).
 
     Some interesting variables…
 en: Some interesting variables…
 fr: Quelques variables intéressantes…
-co:
+co: Qualchì variabile interessante…
 
     Sorry, this file is unknown:
 en: Sorry, this file is unknown:
 fr: Désolé. Ce fichier est inconnu :
-co:
+co: Per disgrazia, stu schedariu hè scunnisciutu :
 
     Specifiy the number of branches to be deleted.
 en: Specifiy the number of branches to be deleted.
 fr: Définit le nombre de branches à supprimer.
-co:
+co: Definisce u contu di ghjembe à squassà.
 
     Starting directory and database
 en: Starting directory and database
 fr: Répertoire et base de départ
-co:
+co: Cartulare è basa di dati d’origine
 
     Starting person in first base.<br> <span style="color:#FF0000;">Mandatory parameter</span>
 en: Starting person in first base.<br> <span style="color:#FF0000;">Mandatory parameter</span>
 fr: Personne racine dans la première base.<br> <span style="color:#FF0000;">Paramètre obligatoire</span>
-co:
+co: Persona di principu in a prima basa.<br> <span style="color:#FF0000;">Parametru ubblicatoriu</span>
 
     Starting person in second base.<br> <span style="color:#FF0000;">Mandatory parameter</span>
 en: Starting person in second base.<br> <span style="color:#FF0000;">Mandatory parameter</span>
 fr: Personne racine dans la seconde base.<br> <span style="color:#FF0000;">Paramètre obligatoire</span>
-co:
+co: Persona di principu in a seconda basa.<br> <span style="color:#FF0000;">Parametru ubblicatoriu</span>
 
     Surname
 en: Surname
 fr: Nom
-co:
+co: Casata
 
     text color
 en: text color
 fr: couleur du texte
-co:
+co: culore di u testu
 
     text|link|vlink
 en: text|link|vlink
 fr: texte|lien|visité
-co:
+co: testu|liame|visitatu
 
     The accentuated characters are in ANSEL encoding.
 en: The accentuated characters are in ANSEL encoding.
 fr: Les lettres accentuées sont en codage ANSEL.
-co:
+co: I caratteri cù l’aletta sò in cudificazione ANSEL.
 
     The accentuated characters are in ANSI encoding (ISO 8859-1).
 en: The accentuated characters are in ANSI encoding (ISO 8859-1).
 fr: Les lettres accentuées sont en codage ANSI (ISO 8859-1).
-co:
+co: I caratteri cù l’aletta sò in cudificazione ANSI (ISO 8859-1).
 
     The accentuated characters are in ASCII encoding.
 en: The accentuated characters are in ASCII encoding.
 fr: Les lettres accentuées sont en codage ASCII.
-co:
+co: I caratteri cù l’aletta sò in cudificazione ASCII.
 
     The accentuated characters are in MSDOS encoding.
 en: The accentuated characters are in MSDOS encoding.
 fr: Les lettres accentuées sont en codage MSDOS.
-co:
+co: I caratteri cù l’aletta sò in cudificazione MSDOS.
 
     The accentuated characters encoding is normally specified in the GEDCOM header.
 en: The accentuated characters encoding is normally specified in the GEDCOM header.
 fr: Le codage des lettres accentuées est en principe indiqué dans l’entête du fichier GEDCOM.
-co:
+co: A cudificazione di i caratteri cù l’aletta si trova da bona regula in l’intestatura du u schedariu GEDCOM.
 
     The advanced request allows to make researches in the data base. As it is very incomplete, it is hidden by default. Select "no" below to set it.
 en: The advanced request allows to make researches in the data base. As it is very incomplete, it is hidden by default. Select "no" below to set it.
 fr: La requête évoluée permet de faire des recherches avec critères sur la base. Comme elle est très incomplète, elle est cachée par défaut. Sélectionnez "non" ci-dessous pour la remettre.
-co:
+co: A richiesta esperta permette di fà ricerche cù criterii nant’à a basa. Cum’è hè assai incompleta, hè predefinita piattata. Selezziunate « Innò » quaghjò per rimettela.
 
     The cleaning up of you database "%a" is completed.
 en: So. The cleaning up of you database "%a" is completed.
 fr: Le nettoyage de votre base "%a" est terminé.
-co:
+co: Eccu. A nettata di a vostra basa di dati « %a » hè compia.
 
     The command "%d" exited with an error code. This operation may have not been done.
 en: The command "%d" exited with an error code. This operation may have not been done.
 fr: La commande "%d" s’est terminée avec un code d’erreur. Il se peut que cette opération n’ait pas pu être faite.
-co:
+co: A cumanda « %d » s’hè piantata cù un codice di sbagliu. Forse st’operazione ùn hè micca stata trattata.
 
     the existing databases
 en: the existing databases
 fr: les bases de données existantes
-co:
+co: e base di dati esistente
 
     The extraction of the %G source file is terminated.
 en: The extraction of the %G source file is terminated.
 fr: L’extraction du fichier %G est terminée.
-co:
+co: L’estrazzione di u schedariu di fonte %G hè compia.
 
     The extraction of the GEDCOM file is terminated.
 en: The extraction of the GEDCOM file is terminated.
 fr: Voilà. L’extraction du fichier GEDCOM est terminée.
-co:
+co: L’estrazzione di u schedariu GEDCOM hè compia.
 
     The initialization of consanguinities is necessary so that the consanguinities are displayed when browsing the database.
 en: The initialization of consanguinities is necessary so that the consanguinities are displayed when browsing the database.
 fr: L’initialisation des consanguinités est nécessaire pour que les consanguinités s’affichent quand on navigue dans la base.
-co:
+co: U prugramma d’iniziu di e cunsanguinità hè necessariu per chì e cunsanguinità s’affisseghjinu quandu si navigheghja in a basa di dati.
 
     The name "%o" is used several times.
 en: The name "%o" is used several times.
 fr: Le nom "%o" est utilisé plusieurs fois.
-co:
+co: U nome « %o » hè impiegatu parechje volte.
 
     The name of a database is made of non accentuated letters (uppercase or lowercase), digits and of the character "-". Other characters (particularly space) are forbidden.
 en: The name of a database is made of non accentuated letters (uppercase or lowercase), digits and of the character "-". Other characters (particularly space) are forbidden.
 fr: Le nom d’une base de données est constitué de lettres non accentuées (majuscules ou minuscules), de chiffres et du caractère « - ». Tout autre caractère (en particulier l’espace) est interdit.
-co:
+co: U nome d’una basa di dati hè fattu da lettere senza aletta (maiuscule o minuscule), cifri è di u caratteru « - ». L’altri caratteri (è dunque u spaziu) sò difesi.
 
     The operation "%d" on the database "%a" is terminated.
 en: The operation "%d" on the database "%a" is terminated.
 fr: L’opération "%d" sur la base "%a" est terminée.
-co:
+co: L’operazione « %d » nant’à a basa di dati « %a » hè compia.
 
     The operation "%d" will be applied on your database "%a". Warning: it can take some seconds or some minutes, depending on the case. Be patient.
 en: The operation "%d" will be applied on your database "%a". Warning: it can take some seconds or some minutes, depending on the case. Be patient.
 fr: L’opération "%d" va être appliquée sur votre base "%a". Attention: l’opération peut prendre quelques secondes ou quelques minutes, suivant les cas. Soyez patient.
-co:
+co: L’operazione « %d » hà da esse appiecata nant’à a vostra basa di dati « %a ». Avertimentu : st’operazione pò piglià da qualchì seconda à parechji minuti secondu à u casu. Aspettate per piacè.
 
     The parameters are recorded in the text file "%a.gwf" in the directory "%w".
 en: The parameters are recorded in the text file "%a.gwf" in the directory "%w".
 fr: Les paramètres sont enregistrés dans le fichier texte "%a.gwf" dans le répertoire "%w".
-co:
+co: I parametri sò arregistrati in u schedariu di testu « %a.gwf » in u cartulare « %w ».
 
     The previous command exited with an error code. Your database "%o" may have not been created.
 en: The previous command exited with an error code. Your database "%o" may have not been created.
 fr: La commande précédente s’est terminée avec un code d’erreur. Il se peut que votre base de données "%o" n’ait pas été créée.
-co:
+co: A cumanda precedente s’hè piantata cù un codice di sbagliu. Forse a vostra basa di dati « %o » ùn hè micca stata creata.
 
     The previous command exited with an error code. Your database may have not been created.
 en: The previous command exited with an error code. Your database may have not been created.
 fr: La commande précédente s’est terminée avec un code d’erreur. Il se peut que votre base de données "%o" n’ait pas été créée.
-co:
+co: A cumanda precedente s’hè piantata cù un codice di sbagliu. Forse a vostra basa di dati ùn hè micca stata creata.
 
     The previous page is outdated.
 en: The previous page is outdated.
 fr: La page précédente n’est pas à jour.
-co:
+co: A pagina precedente ùn hè micca attuale.
 
     the traces of the latest command
 en: the traces of the latest command<
 fr: les traces de la dernière commande effectuée
-co:
+co: e traccie di l’ultima cumanda passata
 
     Then click on this button
 en: Then press this button
 fr: Puis appuyez sur ce bouton
-co:
+co: Tandu appughjate nant’à stu buttone
 
     Then push this button
 en: Then push this button
 fr: Puis appuyez sur ce bouton
-co:
+co: Tandu appughjate nant’à stu buttone
 
     there is no database
 en: there is no database
 fr: il n’y a aucune base de données
-co:
+co: ùn ci hè alcuna basa di dati
 
     there is no database at present
 en: here is no database at present
 fr: il n’y a aucune base de données actuellement
-co:
+co: ùn ci hè alcuna basa di dati à stu mumentu
 
     there is no databases in this directory
 en: there is no databases in this directory
 fr: il n’y a aucune base de données dans ce répertoire
-co:
+co: ùn ci hè alcuna basa di dati in stu cartulare
 
     There is no directory with this name
 en: There is no directory with this name
 fr: Il n’y a pas de répertoire portant ce nom
-co:
+co: Ùn ci hè micca cartulare di stu nome
 
     This applies not only to the welcome page but to all the displayed pages for this database.
 en: This applies not only to the welcome page but to all the displayed pages for this database.
 fr: Ceci s’applique non seulement à la page d’accueil mais à toutes les pages affichées de cette base.
-co:
+co: Què ùn s’appiecherà micca solu à a pagina d’accolta ma dinù à tutte e pagine affissate di sta basa di dati.
 
     This builds a directory named "%o.gwb".
 en: This builds a directory named "%o.gwb".
 fr: Cela fabriquera un répertoire de nom "%o.gwb".
-co:
+co: Què custruiscerà un cartulare di nome « %o.gwb »
 
     This can be useful, temporarilly, when you make a cleanup of your database, if it is accessible to Internet, to avoid that "wizards" make changes which would be lost during the operation (remember to suppress this option after cleanup).
 en: This can be useful, temporarilly, when you make a cleanup of your database, if it is accessible to Internet, to avoid that "wizards" make changes which would be lost during the operation (remember to suppress this option after cleanup).
 fr: Cela peut-être utile, temporairement, quand on fait un nettoyage de la base, si elle est accessible sur Internet, pour éviter que des "magiciens" ne fassent des mises-à-jour qui seraient perdues pendant l’opération (penser alors à supprimer cette option après nettoyage).
-co:
+co: St’ozzione pò esse ghjuvevule, timpurariamente, quandu si face una nettata di a vostra basa di dati, s’ella hè acciduta da Internet, per impedisce chì certi « maghi » faccianu mudificazioni chì serianu perse durante l’operazione (ma arricurdatevi di squassà st’ozzione dopu a nettata).
 
     This file is in the directory
 en: This file is in the directory
 fr: Ce fichier se trouve dans le répertoire
-co:
+co: Stu schedariu si trova in u cartulare
 
     This file is in the directory "%w".
 en: This file is in the directory "%w".
 fr: Ce fichier se trouve dans le répertoire "%w".
-co:
+co: Stu schedariu si trova in u cartulare « %w »
 
     This has built a file named "%o".
 en: This has built a file named "%o".
 fr: Cela a construit un fichier de nom "%o".
-co:
+co: Què hà custruitu un schedariu chjamatu « %o ».
 
     To change that, edit the file named "%y" and change the line holding: "<tt>%o</tt>" into "<tt>%a</tt>".
 en: To change that, edit the file named "%y" and change the line holding: "<tt>%o</tt>" into "<tt>%a</tt>".
 fr: Pour outrepasser cet interdit, il faut éditer le fichier "%y" et remplacer la ligne contenant "<tt>%o</tt>" en "<tt>%a</tt>".
-co:
+co: Per francà st’interdettu, ci vole à mudificà u schedariu « %y » è rimpiazzà a linea cuntenendu <tt>%o</tt>" da "<tt>%a</tt>".
 
     To consult a database, the gwd service must have been launched.
 en: To consult a database, the gwd service must have been launched.
 fr: Pour consulter une base de données, il faut que le service gwd soit lancé.
-co:
+co: Per cunsultà una basa di dati, u serviziu gwd deve esse lanciatu.
 
     To consult your database, and possibly modify it, the gwd service must have been launched.
 en: To consult your database, and possibly modify it, the gwd service must have been launched.
 fr: Pour la consulter et éventuellement la modifier, assurez-vous que  gwd soit ouvert.
-co:
+co: Per cunsultà a vostra basa di dati, è forse mudificalla, assicuratevi chì u serviziu gwd sia lanciatu.
 
     To know which value put for your computer, look at the traces of the command "gwd" which are displayed in the log file (see below) each time  you navigate in your databases. You have to put what you see behind the "From:".
 en: To know which value put for your computer, look at the traces of the command "gwd" which are displayed in the log file (see below) each time  you navigate in your databases. You have to put what you see behind the "From:".
 fr: Pour savoir quelle valeur mettre pour votre ordinateur, regardez les traces de la commande "gwd" qui s’affichent dans le fichier log (voir ci-dessous) chaque fois que vous naviguez dans une base de données. Il faut mettre ce que vous voyez derrière le "From:".
-co:
+co: Per sapè chì valore ci vole à sceglie per u vostru urdinatore, fighjate e traccie di a cumanda « gwd » chì si trovanu in u schedariu « log » (fighjate quaghjò) ogni volta chì vò navigate in una basa di dati. Ci vole à mette ciò chì hè scrittu daretu u « From: ».
 
     To restore a gw database, apply the creation from a GeneWeb source file.
 en: To restore a gw database, apply the creation from a %G source file.
 fr: Pour restaurer une base de donnée au format gw appliquez la création à partir d’un fichier source %G.
-co:
+co: Per risturà una basa di dati à u furmatu gw, appiecate a creazione à partesi d’un schedariu di fonte %G.
 
     To save your database, apply the extraction of a GeneWeb source file. Then copy the obtained file elsewhere in the disk, or better, on an external support.
 en: To save your database, apply the extraction of a %G source file. Then copy the obtained file elsewhere in the disk, or better, on an external support.
 fr: Pour sauvegarder votre base de données, appliquez l’extraction d’un fichier source %G. Puis copiez le fichier ainsi obtenu autre part sur le disque, ou mieux, sur un support externe.
-co:
+co: Per fà una salvaguardia di a vostra basa di dati, appiecate l’estrazzione d’un schedariu di fonte %G. È dopu, cupiate u schedariu ottinutu altronde nant’à u discu, o megliu, nant’à una memoria esterna.
 
     To specify a background image for the database "%o", you have to write it:
 en: To specify a background image for the database "%o", you have to write it:
 fr: Pour <b>indiquer une image de fond</b> pour la base "%o", il faut la mettre sous la forme suivante:
-co:
+co: Per specificà una fiura di fondu per a basa di dati « %o », ci vole à mettela sottu sta forma :
 
     To start the service
 en: To start the service
 fr: Pour démarrer le service
-co:
+co: Per principià u serviziu
 
     To stop the service
 en: To stop the service
 fr: Pour arrêter le service
-co:
+co: Per piantà u serviziu
 
     Trace of the latest command
 en: Trace of the latest command
 fr: Traces de la dernière commande
-co:
+co: Traccie di l’ultima cumanda
 
     Traces of the latest command
 en: Traces of the latest command
 fr: Traces de la dernière commande
-co:
+co: Traccie di l’ultima cumanda
 
     Under Linux, if you installed %G as an rpm package, become root and type
 en: Under Linux, if you installed %G as an rpm package, become root and type
 fr: Sous <b>Linux</b>, si vous avez installé %G par un paquetage rpm, devenez root et tapez
-co:
+co: Sottu <b>Linux</b>, s’è vò avete installatu %G da un pacchettu rpm, diventate « root » è scrivite
 
     Under Linux, if you installed %G as an rpm package, the service has been automatically launched. If you stopped it and want to restart it, become root and type
 en: Under Linux, if you installed %G as an rpm package, the service has been automatically launched. If you stopped it and want to restart it, become root and type
 fr: Sous <b>Linux</b>, si vous avez installé %G à partir un paquetage rpm, le service a été automatiquement lancé.  Si vous l’avez arrêté et voulez le relancer, devenez root et tapez
-co:
+co: Sottu <b>Linux</b>, s’è vò avete installatu %G da un pacchettu rpm, u serviziu hè statu lanciatu autumaticamente. S’è vò l’avete piantatu è vulete rilanciallu, diventate « root » è scrivite
 
     Under MSdos
 en: Under MSdos
 fr: Sous MSdos
-co:
+co: Sottu MSdos
 
     Under Unix
 en: Under Unix
 fr: Sous Unix
-co:
+co: Sottu Unix
 
     Under Unix, launch an xterm and type the following commands
 en: Under Unix, launch an xterm and type the following commands
 fr: Sous <b>Unix</b>, lancez un xterm et tapez les commandes suivantes
-co:
+co: Sottu <b>Linux</b>, lanciate un « xterm » è scrivite sta seguita di cumande
 
     Under Windows or Unix, type "control C" in the window where it is running.
 en: Under Windows or Unix, type "control C" in the window where it is running.
 fr: Sous <b>Windows</b> ou <b>Unix</b>, tapez "control C" dans la fenêtre où il tourne.
-co:
+co: Sottu <b>Windows</b> o <b>Linux</b>, scrivite « control C » in a finestra induve ellu funziuneghja.
 
     Under Windows, launch the program "gwd".
 en: Under Windows, launch the program "gwd".
 fr: Sous <b>Windows</b>, lancez le programme "gwd".
-co:
+co: Sottu <b>Windows</b>, lanciate u prugramma « gwd ».
 
     Unknown file
 en: Unknown file
 fr: Fichier inconnu
-co:
+co: Schedariu scunnisciutu
 
     Update_nldb
 en: update_nldb
 fr: update_nldb
-co:
+co: update_nldb
 
     Using <b>gwd</b> to visualize the file in the NOTES folder of your base where you have redirected output (%a.gwb/notes_d/connex.txt).<br> This file contains the last set of data stored at this location (which is not necessarily the one you have just computed - see the time stamp at the head of the file).<br> This solution allows you to follow links to designated persons.
 en: Using <b>gwd</b> to visualize the file in the NOTES folder of your base where you have redirected output (%a.gwb/notes_d/connex.txt).<br> This file contains the last set of data stored at this location (which is not necessarily the one you have just computed - see the time stamp at the head of the file).<br> This solution allows you to follow links to designated persons.
 fr: En utilisant <b>gwd</b> pour visualiser le fichier dans le dossier NOTES où vous avez redirigé les résultats (%a.gwb/notes_d/connex.txt).<br> Vous y verrez la dernière version du fichier connex.txt que vous avez créé à cet endroit (qui n'est pas nécessairement celle que vous venez de calculer - voir l'horodateur en tête de fichier).<br> Cette solution vous permet de suivre les liens vers les personnes désignées.
-co:
+co: Impieghendu <b>gwd</b> per fighjà u schedariu in u cartulare NOTES induve i risultati sò stati ridiretti (%a.gwb/notes_d/connex.txt).<br> Ci viderete l’ultimi dati arregistrati in stu locu (chì ùn sò micca necessariamente quelli chì vò vinite di calculà - fighjate a stampiglia di data è ora in capu di schedariu).<br> Sta suluzione vi permette di seguità i liami ver di e persone indettate.
 
     Using <b>gwsetup</b> to visualize the file in which results were redirected ("%K").
 en: Using <b>gwsetup</b> to visualize the file in which results were redirected ("%K").
 fr: En utilisant <b>gwsetup</b> pour visualiser le fichier vers lequel ont été envoyés les résultats ("%K").
-co:
+co: Impieghendu <b>gwsetup</b> per fighjà u schedariu induve i risultati sò stati ridiretti ("%K").
 
     very quiet mode.
 en: very quiet mode.
 fr: pas de traces du tout.
-co:
+co: manc’appena traccie.
 
     Warning: for this program to work, you must not close this window!
 en: Warning: for this program to work, you must not close this window!
 fr: Attention: pour que cela fonctionne, vous ne devez pas fermer cette fenetre!
-co:
+co: Avertimentu : per chì stu prugramma funziuneghji, ùn duvete micca chjode sta finestra !
 
     Warning: the operation can take several seconds or minutes, depending on the case. Be patient.
 en: <b>Warning</b>: the operation can take several seconds or minutes, depending on the case. Be patient.
 fr: <b>Attention</b> : l’opération peut prendre quelques secondes ou quelques minutes, suivant les cas. Soyez patient.
-co:
+co: <b>Avertimentu</b> : l’operazione pò piglià qualchì seconda o qualchì minutu secondu à u casu. Aspettate per piacè.
 
     Warning: there already exists a database named "%o" in the destination directory. If you push the button below, it will be erased. If you just made this handling, it is probably its result, therefore it is not important. Otherwise, go back and choose another name for your database.
 en: <b>Warning</b>: there already exists a database named "%o" in the destination directory. If you push the button below, it will be erased. If you just made this handling, it is probably its result, therefore it is not important. Otherwise, go back and choose another name for your database.
 fr: <b>Attention</b> : il existe déjà une base de nom "%o" dans le répertoire d’arrivée. Si vous appuyez sur le bouton ci-dessous, cela va l’effacer. Si vous venez déjà de faire cette manipulation, il s’agit probablement de son résultat, ce n’est donc pas grave. Sinon, revenez en arrière et choisissez un autre nom pour votre base.
-co:
+co: <b>Avertimentu</b> : ci hè dighjà una basa di dati chjamata « %o » in u cartulare di destinazione. S’è vò primete nant’à u buttone quaghjò, sta basa serà squassata. S’è vò avete dighjà fattu st’azzione, forse ghjè u so risultatu, è dunque ùn hè micca impurtante. Osinnò, rivinite in daretu è sciglite un altru nome per a vostra basa.
 
     Warning: there already exists a database with the name "%o" in your directory. If you push the button "Ok" below, it will be erased.
 en: <b>Warning</b>: there already exists a database with the name "%o" in your directory. If you push the button "Ok" below, it will be erased.
 fr: <b>Attention</b> : il existe déjà une base de nom "%o" dans votre répertoire. Si vous appuyez sur le bouton "Ok" ci-dessous, cela va l’effacer.
-co:
+co: <b>Avertimentu</b> : ci hè dighjà una basa di dati chjamata « %o » in u vostru cartulare. S’è vò primete nant’à u buttone « Vai » quaghjò, sta genealugia serà squassata.
 
     Warning: this operation can take some seconds or minutes, depending on the cases. Be patient.
 en: <b>Warning</b>: this operation can take some seconds or minutes, depending on the cases. Be patient.
 fr: <b>Attention</b> : l’opération peut prendre quelques secondes ou quelques minutes, suivant les cas. Soyez patient.
-co:
+co: <b>Avertimentu</b> : st’operazione pò piglià qualchì seconda o qualchì minutu secondu à u casu. Aspettate per piacè.
 
     Warning: this suppression is definitive! To confirm, push this button.
 en: <b>Warning</b>: this suppression is definitive! To confirm, push this button.
 fr: <b>Attention</b> : cette suppression est définitive! Pour confirmer, appuyez sur ce bouton:
-co:
+co: <b>Avertimentu</b> : sta squassatura hè irriversibile ! Per cunfirmà, appughjate nant’à stu buttone.
 
     We are going to create a database named "%o" from the following databases:
 en: We are going to create a database named "%o" from the following databases:
 fr: Nous allonc créer une base de nom "%o" à partir des bases suivantes:
-co:
+co: Avemu da creà una basa di dati chì si chjama « %o » à partesi di ste base di dati :
 
     We are going to create a database named "%o". Remark: this operation can answer in the twinkling of a eye or take some tenths of seconds or some minutes, depending on the cases. Be patient.
 en: We are going to create a database named "%o". Remark: this operation can answer in the twinkling of a eye or take some tenths of seconds or some minutes, depending on the cases. Be patient.
 fr: Nous allons créer une généalogie de nom "%o". Remarque : cette opération peut s’effectuer en un clin d’oeil ou prendre quelques dizaines de secondes ou quelques minutes, suivant les cas. Soyez patient.
-co:
+co: Avemu da creà una genealugia chì si chjama « %o ». Rimarca : st’operazione pò fassi in furia o piglià qualchì decine di seconda o parechji minuti secondu à u casu. Aspettate per piacè.
 
     We are going to proceed to the cleaning up of the database "%a".
 en: We are going to proceed to the cleaning up of the database "%a".
 fr: Nous allons procéder au nettoyage de la base "%a".
-co:
+co: Avemu da principià a nettata di a basa di dati « %a ».
 
     Welcome to GeneWeb
 en: Welcome to %G
 fr: Bienvenue dans %G
-co:
+co: Benvenuta in %G
 
     When a person is born less than <num> years ago, it is not exported unless it is Public.<br>  All the spouses and descendants are also censored.
 en: When a person is born less than <num> years ago, it is not exported unless it is Public.<br>  All the spouses and descendants are also censored.
-fr: Quand une personne est née il y a moins de … années, elle n’est pas exportée sauf<br> si elle est "publique". La censure s’applique aux époux et descendants. 
-co:
+fr: Quand une personne est née il y a moins de … années, elle n’est pas exportée sauf<br> si elle est "publique". La censure s’applique aux époux et descendants.
+co: Quand’una persona hè nata menu di <num> anni fà, ùn face micca parte di l’espurtazione for di s’ella hè publica.<br> Tutti i sposi è discendenti sò prutetti dinù.
 
     When ancestors are displayed by tree, limit the number of displayed generations. By default, it is 7 generations, but you can indicate a different value here.
 en: When ancestors are displayed by tree, limit the number of displayed generations. By default, it is 7 generations, but you can indicate a different value here.
 fr: Quand on affiche les ascendants par arbre, limite le nombre de générations affichables. C’est 7 par défaut, mais vous pouvez indiquer une valeur différente ici.
-co:
+co: Quandu s’affisseghja l’arburu cù l’antenati, què limiteghja u numeru di generazioni. U numeru predefinitu hè 7, ma si pò indicà quì un altru valore.
 
     When ancestors are displayed, limit the number of displayed generations. By default, it is 8 generations, but you can indicate a different value here.
 en: When ancestors are displayed, limit the number of displayed generations. By default, it is 8 generations, but you can indicate a different value here.
 fr: Quand on affiche les ascendants, limite le nombre de générations affichables. C’est 8 par défaut, mais vous pouvez indiquer une valeur différente ici.
-co:
+co: Quandu s’affisseghjanu l’antenati, què limiteghja u numeru di generazioni. U numeru predefinitu hè 8, ma si pò indicà quì un altru valore.
 
     When creating a person, if the GEDCOM first name part holds several names separated by spaces, you can ask that the first of this names becomes the person "first name" and the complete GEDCOM first name part a "first name alias" (-no_efn default.
 en: When creating a person, if the GEDCOM first name part holds several names separated by spaces, you can ask that the first of this names becomes the person "first name" and the complete GEDCOM first name part a "first name alias" (-no_efn default.
 fr: Au moment de la création d’une personne, si la partie prénom dans le GEDCOM est formée de plusieurs noms séparés par des espaces, on peut vouloir que le premier de ces noms aille dans la partie « prénom»  et que le prénom complet devienne un « prénom alias»  (<span style="font-family: monospace">-no_efn</span> par défaut).
-co:
+co: Durante a creazione d’una persona, s’è a catena <i>nome</i> di u schedariu GEDCOM cuntene pareghji nomi staccati da spazii, si pò vulè chì u <i>primu nome</i> di sta lista sia cunsideratu cum’è u « nome » è chì u <i>nome cumpletu</i> di u GEDCOM vochi in u « cugnome di nome » (valore <span style="font-family: monospace">-no_efn</span> predefinitu).
 
     When descendants are displayed by tree, limit the number of displayed generations. By default, it is 4 generations, but you can indicate a different value here.
 en: When descendants are displayed by tree, limit the number of displayed generations. By default, it is 4 generations, but you can indicate a different value here.
 fr: Quand on affiche les descendants par arbre, limite le nombre de générations affichables. C’est 4 par défaut, mais vous pouvez indiquer une valeur différente ici.
-co:
+co: Quandu s’affisseghja l’arburu cù i discendenti, què limiteghja u numeru di generazioni. U numeru predefinitu hè 4, ma si pò indicà quì un altru valore.
 
     When descendants are displayed, limit the number of displayed generations. By default, it is 12 generations, but you can indicate a different value here.
 en: When descendants are displayed, limit the number of displayed generations. By default, it is 12 generations, but you can indicate a different value here.
 fr: Quand on affiche les descendants, limite le nombre de générations affichables. C’est 12 par défaut, mais vous pouvez indiquer une valeur différente ici.
-co:
+co: Quandu s’affisseghjanu i discendenti, què limiteghja u numeru di generazioni. U numeru predefinitu hè 12, ma si pò indicà quì un altru valore.
 
     with the simple method
 en: with the simple method
 fr: avec la méthode simple
-co:
+co: cù a metoda simplice
 
     Write the name you want for your database
 en: Write the name you want for your database
 fr: Indiquez le nom que vous voulez donner à votre base de données
-co:
+co: Scrivite u nome chì vò vulete dà à a vostra basa di dati
 
     Write the name you want to give to your database. By default, it will be the same in the new directory.
 en: Write the name you want to give to your database. By default, it will be the same in the new directory.
 fr: Indiquez le nom que vous voulez donner à votre base de données. Par défaut, ce sera le même dans le nouveau répertoire.
-co:
+co: Scrivite u nome chì vò vulete dà à a vostra basa di dati. Di regula, serà u listessu nome in u novu cartulare.
 
     Years
 en: Years
 fr: Années
-co:
+co: Anni
 
     yes|no
 en: Yes|No
 fr: oui|non
-co:
+co: Iè|iNnò
 
     You are not allowed to access this service. Only the address "%o" can use it.
 en: You are not allowed to access this service. Only the address "%o" can use it.
 fr: <p> Vous n’avez pas l’autorisation d’accéder à ce service. Seule l’adresse "%o" peut l’utiliser.
-co:
+co: Ùn avete micca u permessu d’accede à stu serviziu. Solu l’indirizzu « %o » pò impiegallu.
 
     You can also select one of the proposed colors combinations.
 en: You can also select one of the proposed colors combinations.
 fr: Vous pouvez aussi sélectionner une des combinaisons de couleurs proposées.
-co:
+co: Pudete dinù selezziunà una di l’aggalabate di culore pruposte.
 
     You can consult it
 en: You can consult it
 fr: Vous pouvez la consulter
-co:
+co: Pudete cunsultalla
 
     You can consult your very clean new database
 en: You can consult your very clean new database
 fr: Vous pouvez consulter votre nouvelle base toute propre
-co:
+co: Pudete cunsultà a vostra basa di dati netta netta
 
     You can select an option
 en: You can select an option
 fr: Vous pouvez sélectionner une option
-co:
+co: Pudete selezziunà un’ozzione
 
     You cannot choose "%o" as database name, because it holds forbidden characters.
 en: You cannot choose "%o" as database name, because it holds forbidden characters.
 fr: Vous ne pouvez pas choisir "%o" comme nom de base de données car il contient des caractères interdits.
-co:
+co: Ùn pudete micca sceglie « %o » cum’è nome di basa di dati chì ellu cuntene caratteri difesi.
 
     You may have come from a too old version of %G. In this case, try again to do the transfer using the option to "pass by a GEDCOM file" (you can also go back to the previous screen to do it).
 en: You may have come from a too old version of %G. In this case, try again to do the transfer using the option to "pass by a GEDCOM file" (you can also go back to the previous screen to do it).
 fr: Il se peut que vous soyez parti d’une trop ancienne version de %G. Dans ce cas, réessayez de faire le transfert en mettant l’option de « passer par un fichier GEDCOM ».
-co:
+co: Forse site partutu(a) d’una versione à l’anticogna di %G. In tale casu, pruvate torna di fà u trasferimentu impieghendu l’ozzione « Passate da un schedariu GEDCOM » (pudete fallu dinù da u screnu precedente).
 
     You may observe results through two means
 en: You may observe results through two means
 fr: Vous pouvez consulter les résultats de deux façons différentes
-co:
+co: Pudete cunsultà i risultati da duie manere sfarente
 
     You selected the directory
 en: You selected the directory
 fr: Vous avez sélectionné le répertoire
-co:
+co: Avete selezziunatu u cartulare
 
     You selected the same directory than the one of this %G distribution.
 en: You selected the same directory than the one of this %G distribution.
 fr: Vous avez sélectionné le même répertoire que celui de cette distribution de %G.
-co:
+co: Avete selezziunatu u listessu cartulare chì quellu di sta distribuzione %G.
 
     Your database has been completely rebuilt: the old version is on the subdirectory "old" of the directory "%w". You can recover it in case of problem.
 en: Your database has been completely rebuilt: the old version is on the subdirectory "old" of the directory "%w". You can recover it in case of problem.
 fr: Votre base a été complètement reconstruite : l’ancienne version se trouve dans le sous-répertoire "old" du répertoire "%w". Vous pouvez l’y récupérer en cas de problème.
-co:
+co: A vostra basa di dati hè stata cumpletamente ricustruita : a vechja versione si trova in u sottu-cartulare « old » di u cartulare « %w ». Ci pudete ricuperalla in casu di prublema.
 
     Your databases have been renamed. Here is the new list
 en: Your databases have been renamed. Here is the new list
 fr: Vos bases de données ont été renommées. Voici la nouvelle liste
-co:
-
+co: E vostre base di dati sò state rinuminate. Eccu a nova lista

--- a/hd/lang/missing/lex_co.txt
+++ b/hd/lang/missing/lex_co.txt
@@ -4,10 +4,10 @@ co:
     a child-in-law/children-in-law
 en: one child-in-law/children-in-law
 fr: un bel-enfant/beaux-enfants
-co:
+co: un ghjeneru o una nora/ghjeneri o nore
 
     pacsed%t to
 en: Civil solidarity pact%t with
 fr: PACS%t avec
-co:
+co: PACS%t cù
 


### PR DESCRIPTION
Hello Henri,

I just completed the translation in **Corsican** of all the strings found in file `lex_co.txt`.

The updated version committed in this PR now contains Corsican translation in addition to English and French ones.

Regarding my two previous questions in #1 , I put the following strings:

	co: Connex
	co: Consang
	co: zitelli - famiglie.
	co: genitori - famiglie.
	co: testimoni - « fevents ».
	co: divorziu - matrimoniu.
	co: famiglie - persone.
	co: NBDS - persone.
	co: genitori - persone.
	co: testimoni - « pevents ».

	co: Quand’una persona hè nata menu di <num> anni fà, ùn face micca parte di l’espurtazione for di s’ella hè publica.<br> Tutti i sposi è discendenti sò prutetti dinù.

If you give me more details I will be able to modify them if necessary..

Cheers,
Patriccollu.