### PR TITLE
Static path cleanup

### DIFF
--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -1294,7 +1294,7 @@ let make_conf from_addr request script_name env =
        if !images_url <> "" then !images_url
        else if !(Wserver.cgi) then
           begin match Sys.getenv_opt "GW_STATIC_PATH" with
-          | Some x -> String.concat Filename.dir_sep [x; ".."; ".."; "images"]
+          | Some x -> String.concat Filename.dir_sep [x; ".."; "images"]
               (* Assumes that GW_STATIC_PATH is ../distribution/gw/etc  *)
           | None -> String.concat Filename.dir_sep
               [".."; "distribution"; "gw"; "images" ]
@@ -1306,7 +1306,7 @@ let make_conf from_addr request script_name env =
        else "images";
      static_path =
        begin match Sys.getenv_opt "GW_STATIC_PATH" with
-       | Some x -> x
+       | Some x -> String.concat Filename.dir_sep [x; ""]
        | None -> String.concat Filename.dir_sep [".."; "distribution"; "gw"; "etc"; "" ]
          (* FIXME same comment. / at the end! *)
        end;

--- a/hd/etc/carrousel.txt
+++ b/hd/etc/carrousel.txt
@@ -404,7 +404,7 @@ document.getElementById("image_name").focus();
 </script>
 %( Possible heavier futur script to manage multiple files inputs
    https://github.com/Johann-S/bs-custom-file-input/blob/master/dist/bs-custom-file-input.min.js
-<script src=%if;(cgi)%bvar.static_path;%end;js/bs-custom-file-input.min.js></script>
+<script src=%static_path;js/bs-custom-file-input.min.js></script>
 <script>$(document).ready(function(){bsCustomFileInput.init()})</script> %)
 
 </body>

--- a/hd/etc/templm/doc_templm.txt
+++ b/hd/etc/templm/doc_templm.txt
@@ -164,7 +164,7 @@
   <td>
     En mode CGI :
     <ul>
-      <li>static_path=…/ : chemin statique des fichiers CSS et js</li>
+      <li>remplacé par GW_STATIC_PATH depuis la version  7.1, chemin statique des fichiers CSS et js</li>
     </ul>
   </td>
 </tr>

--- a/lib/templ.ml
+++ b/lib/templ.ml
@@ -495,9 +495,7 @@ and eval_simple_variable conf = function
   | "static_path" ->
       (let s =
          if conf.cgi then
-           match List.assoc_opt "static_path" conf.base_env with
-           | Some x -> Adef.escaped x
-           | None -> Adef.escaped conf.static_path
+           Adef.escaped conf.static_path
          else Adef.escaped ""
        in
        s

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -35,12 +35,14 @@ let time_debug conf query_time nb_errors errors_undef errors_other set_vars =
        home_time.classList.add("text-danger");
     }
   }
-  if (home_errors != null && nb_errors > 0) {
-    home_errors.title = nb_errors +" error(s)!";
-    home_errors.classList.remove("d-none");
-  }
-  if (home_errors != null && errors_list != "") {
-    home_errors.title = home_errors.title + errors_list + ".";
+  if (home_errors != null) {
+    if (nb_errors > 0) {
+      home_errors.title = nb_errors +" error(s)!";
+      home_errors.classList.remove("d-none");
+    }
+    if (errors_list != "") {
+      home_errors.title = home_errors.title + errors_list + ".";
+    }
   }
 </script>|}
            query_time nb_errors


### PR DESCRIPTION
Static path cleanup
*  Do not overwrite static_path by bvar if still present
*  Replace %bvar.static_path; by %static_path; (step3)
*  Handle properly GW_STATIC_PATH in gwd.ml

and something else
* Avoid Uncaught TypeError: home_errors is null in welcome page

@hgouraud, please could you  merge in fix-rl ?

see commit headers for detailed comments for each